### PR TITLE
Update markdown syntax for remark code line highlighting

### DIFF
--- a/docs/tutorial/a-second-page-and-a-link.md
+++ b/docs/tutorial/a-second-page-and-a-link.md
@@ -16,30 +16,30 @@ Notice that we didn't specify a route path this time. If you leave it off the `r
 
 http://localhost:8910/about should show our new page. But no one's going to find it by manually changing the URL so let's add a link from our homepage to the About page and vice versa. We'll start creating a simple header and nav bar at the same time on the HomePage:
 
-```javascript{3,7-19}
+```javascript {3,7-19}
 // web/src/pages/HomePage/HomePage.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const HomePage = () => {
-  return (
-    <>
-      <header>
-        <h1>Redwood Blog</h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>Home</main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>Redwood Blog</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>Home</main>
+		</>
+	);
+};
 
-export default HomePage
+export default HomePage;
 ```
 
 Let's point out a few things here:
@@ -55,36 +55,33 @@ Let's point out a few things here:
 
 Once we get to the About page we don't have any way to get back so let's add a link there as well:
 
-```javascript{3,7-25}
+```javascript {3,7-25}
 // web/src/pages/AboutPage/AboutPage.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const AboutPage = () => {
-  return (
-    <>
-      <header>
-        <h1>Redwood Blog</h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>
-        <p>
-          This site was created to demonstrate my mastery of Redwood: Look on my
-          works, ye mighty, and despair!
-        </p>
-        <Link to={routes.home()}>Return home</Link>
-      </main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>Redwood Blog</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>
+				<p>This site was created to demonstrate my mastery of Redwood: Look on my works, ye mighty, and despair!</p>
+				<Link to={routes.home()}>Return home</Link>
+			</main>
+		</>
+	);
+};
 
-export default AboutPage
+export default AboutPage;
 ```
 
 Great! Try that out in the browser and verify you can get back and forth.

--- a/docs/tutorial/authentication.md
+++ b/docs/tutorial/authentication.md
@@ -87,47 +87,47 @@ We'll hook up both the web and api sides below to make sure a user is only doing
 
 First let's lock down the API so we can be sure that only authorized users can create, update and delete a Post. Open up the Post service and let's add a check:
 
-```javascript{4,17,24,32}
+```javascript {4,17,24,32}
 // api/src/services/posts/posts.js
 
-import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
+import { db } from "src/lib/db";
+import { requireAuth } from "src/lib/auth";
 
 export const posts = () => {
-  return db.post.findMany()
-}
+	return db.post.findMany();
+};
 
 export const post = ({ id }) => {
-  return db.post.findOne({
-    where: { id },
-  })
-}
+	return db.post.findOne({
+		where: { id },
+	});
+};
 
 export const createPost = ({ input }) => {
-  requireAuth()
-  return db.post.create({
-    data: input,
-  })
-}
+	requireAuth();
+	return db.post.create({
+		data: input,
+	});
+};
 
 export const updatePost = ({ id, input }) => {
-  requireAuth()
-  return db.post.update({
-    data: input,
-    where: { id },
-  })
-}
+	requireAuth();
+	return db.post.update({
+		data: input,
+		where: { id },
+	});
+};
 
 export const deletePost = ({ id }) => {
-  requireAuth()
-  return db.post.delete({
-    where: { id },
-  })
-}
+	requireAuth();
+	return db.post.delete({
+		where: { id },
+	});
+};
 
 export const Post = {
-  user: (_obj, { root }) => db.post.findOne({ where: { id: root.id } }).user(),
-}
+	user: (_obj, { root }) => db.post.findOne({ where: { id: root.id } }).user(),
+};
 ```
 
 Now try creating, editing or deleting a post from our admin pages. Nothing happens! Should we show some kind of friendly error message? In this case, probably not—we're going to lock down the admin pages altogether so they won't be accessible by a browser. The only way someone would be able to trigger these errors in the API is if they tried to access the GraphQL endpoint directly, without going through our UI. The API is already returning an error message (open the Web Inspector in your browser and try that create/edit/delete again) so we are covered.
@@ -142,30 +142,30 @@ Now try creating, editing or deleting a post from our admin pages. Nothing happe
 
 Now we'll restrict access to the admin pages completely unless you're logged in. The first step will be to denote which routes will require that you be logged in. Enter the `<Private>` tag:
 
-```javascript{3,12,16}
+```javascript {3,12,16}
 // web/src/Routes.js
 
-import { Router, Route, Private } from '@redwoodjs/router'
+import { Router, Route, Private } from "@redwoodjs/router";
 
 const Routes = () => {
-  return (
-    <Router>
-      <Route path="/contact" page={ContactPage} name="contact" />
-      <Route path="/about" page={AboutPage} name="about" />
-      <Route path="/" page={HomePage} name="home" />
-      <Route path="/blog-post/{id:Int}" page={BlogPostPage} name="blogPost" />
-      <Private unauthenticated="home">
-        <Route path="/admin/posts/new" page={NewPostPage} name="newPost" />
-        <Route path="/admin/posts/{id:Int}/edit" page={EditPostPage} name="editPost" />
-        <Route path="/admin/posts/{id:Int}" page={PostPage} name="post" />
-        <Route path="/admin/posts" page={PostsPage} name="posts" />
-      </Private>
-      <Route notfound page={NotFoundPage} />
-    </Router>
-  )
-}
+	return (
+		<Router>
+			<Route path="/contact" page={ContactPage} name="contact" />
+			<Route path="/about" page={AboutPage} name="about" />
+			<Route path="/" page={HomePage} name="home" />
+			<Route path="/blog-post/{id:Int}" page={BlogPostPage} name="blogPost" />
+			<Private unauthenticated="home">
+				<Route path="/admin/posts/new" page={NewPostPage} name="newPost" />
+				<Route path="/admin/posts/{id:Int}/edit" page={EditPostPage} name="editPost" />
+				<Route path="/admin/posts/{id:Int}" page={PostPage} name="post" />
+				<Route path="/admin/posts" page={PostsPage} name="posts" />
+			</Private>
+			<Route notfound page={NotFoundPage} />
+		</Router>
+	);
+};
 
-export default Routes
+export default Routes;
 ```
 
 Surround the routes you want to be behind authentication and optionally add the `unauthenticated` attribute that lists the name of another route to redirect to if the user is not logged in. In this case we'll go back to the homepage.
@@ -174,41 +174,39 @@ Try that in your browser. If you hit http://localhost:8910/admin/posts you shoul
 
 Now all that's left to do is let the user actually log in! If you've built authentication before then you know this part is usually a drag, but Redwood makes it a walk in the park. Most of the plumbing was handled by the auth generator, so we get to focus on the parts the user actually sees. First, let's add a **Login** link that will trigger a modal from the [Netlify Identity widget](https://github.com/netlify/netlify-identity-widget). Let's assume we want this on all of the public pages, so we'll put it in the `BlogLayout`:
 
-```javascript{4,7,22-26}
+```javascript {4,7,22-26}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
-import { useAuth } from '@redwoodjs/auth'
+import { Link, routes } from "@redwoodjs/router";
+import { useAuth } from "@redwoodjs/auth";
 
 const BlogLayout = ({ children }) => {
-  const { logIn } = useAuth()
+	const { logIn } = useAuth();
 
-  return (
-    <div>
-      <h1>
-        <Link to={routes.home()}>Redwood Blog</Link>
-      </h1>
-      <nav>
-        <ul>
-          <li>
-            <Link to={routes.about()}>About</Link>
-          </li>
-          <li>
-            <Link to={routes.contact()}>Contact</Link>
-          </li>
-          <li>
-            <button onClick={logIn}>
-              Log In
-            </button>
-          </li>
-        </ul>
-      </nav>
-      <main>{children}</main>
-    </div>
-  )
-}
+	return (
+		<div>
+			<h1>
+				<Link to={routes.home()}>Redwood Blog</Link>
+			</h1>
+			<nav>
+				<ul>
+					<li>
+						<Link to={routes.about()}>About</Link>
+					</li>
+					<li>
+						<Link to={routes.contact()}>Contact</Link>
+					</li>
+					<li>
+						<button onClick={logIn}>Log In</button>
+					</li>
+				</ul>
+			</nav>
+			<main>{children}</main>
+		</div>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 Try clicking the login link:
@@ -235,41 +233,39 @@ Once you do that the modal should update and say that you're logged in! It worke
 
 We've got no indication on our actual site that we're logged in, however. How about changing the **Log In** button to be **Log Out** when you're authenticated:
 
-```javascript{7,23-24}
+```javascript {7,23-24}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
-import { useAuth } from '@redwoodjs/auth'
+import { Link, routes } from "@redwoodjs/router";
+import { useAuth } from "@redwoodjs/auth";
 
 const BlogLayout = ({ children }) => {
-  const { logIn, logOut, isAuthenticated } = useAuth()
+	const { logIn, logOut, isAuthenticated } = useAuth();
 
-  return (
-    <div>
-      <h1>
-        <Link to={routes.home()}>Redwood Blog</Link>
-      </h1>
-      <nav>
-        <ul>
-          <li>
-            <Link to={routes.about()}>About</Link>
-          </li>
-          <li>
-            <Link to={routes.contact()}>Contact</Link>
-          </li>
-          <li>
-            <button onClick={isAuthenticated ? logOut : logIn}>
-              {isAuthenticated ? 'Log Out' : 'Log In'}
-            </button>
-          </li>
-        </ul>
-      </nav>
-      <main>{children}</main>
-    </div>
-  )
-}
+	return (
+		<div>
+			<h1>
+				<Link to={routes.home()}>Redwood Blog</Link>
+			</h1>
+			<nav>
+				<ul>
+					<li>
+						<Link to={routes.about()}>About</Link>
+					</li>
+					<li>
+						<Link to={routes.contact()}>Contact</Link>
+					</li>
+					<li>
+						<button onClick={isAuthenticated ? logOut : logIn}>{isAuthenticated ? "Log Out" : "Log In"}</button>
+					</li>
+				</ul>
+			</nav>
+			<main>{children}</main>
+		</div>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 `useAuth()` provides a couple more helpers for us, in this case `isAuthenticated` which will return `true` or `false` based on your login status, and `logOut()` which will log the user out. Now clicking **Log Out** should log you out and change the link to **Log In** which you can click to open the modal and log back in again.
@@ -280,42 +276,40 @@ When you _are_ logged in, you should be able to access the admin pages again: ht
 
 One more touch: let's show the email address of the user that's logged in. We can get the `currentUser` from `useAuth()` and it will contain the data that our third party authentication library is storing about the currently logged in user:
 
-```javascript{7,27}
+```javascript {7,27}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
-import { useAuth } from '@redwoodjs/auth'
+import { Link, routes } from "@redwoodjs/router";
+import { useAuth } from "@redwoodjs/auth";
 
 const BlogLayout = ({ children }) => {
-  const { logIn, logOut, isAuthenticated, currentUser } = useAuth()
+	const { logIn, logOut, isAuthenticated, currentUser } = useAuth();
 
-  return (
-    <div>
-      <h1>
-        <Link to={routes.home()}>Redwood Blog</Link>
-      </h1>
-      <nav>
-        <ul>
-          <li>
-            <Link to={routes.about()}>About</Link>
-          </li>
-          <li>
-            <Link to={routes.contact()}>Contact</Link>
-          </li>
-          <li>
-            <button onClick={isAuthenticated ? logOut : logIn}>
-              {isAuthenticated ? 'Log Out' : 'Log In'}
-            </button>
-          </li>
-          {isAuthenticated && <li>{currentUser.email}</li>}
-        </ul>
-      </nav>
-      <main>{children}</main>
-    </div>
-  )
-}
+	return (
+		<div>
+			<h1>
+				<Link to={routes.home()}>Redwood Blog</Link>
+			</h1>
+			<nav>
+				<ul>
+					<li>
+						<Link to={routes.about()}>About</Link>
+					</li>
+					<li>
+						<Link to={routes.contact()}>Contact</Link>
+					</li>
+					<li>
+						<button onClick={isAuthenticated ? logOut : logIn}>{isAuthenticated ? "Log Out" : "Log In"}</button>
+					</li>
+					{isAuthenticated && <li>{currentUser.email}</li>}
+				</ul>
+			</nav>
+			<main>{children}</main>
+		</div>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 ![Logged in email](https://user-images.githubusercontent.com/300/82389433-05b2e680-99f1-11ea-9d01-456cad508c80.png)

--- a/docs/tutorial/cells.md
+++ b/docs/tutorial/cells.md
@@ -121,45 +121,45 @@ However, this is not a valid query name for our existing Posts SDL (`src/graphql
 
 We'll have to rename that to just `posts` in both the query name and in the prop name in `Success`:
 
-```javascript{5,17,18}
+```javascript {5,17,18}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
 export const QUERY = gql`
-  query BlogPostsQuery {
-    posts {
-      id
-    }
-  }
-`
+	query BlogPostsQuery {
+		posts {
+			id
+		}
+	}
+`;
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <div>Loading...</div>;
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <div>Empty</div>;
 
-export const Failure = ({ error }) => <div>Error: {error.message}</div>
+export const Failure = ({ error }) => <div>Error: {error.message}</div>;
 
 export const Success = ({ posts }) => {
-  return JSON.stringify(posts)
-}
+	return JSON.stringify(posts);
+};
 ```
 
 Let's plug this cell into our `HomePage` and see what happens:
 
-```javascript{4,9}
+```javascript {4,9}
 // web/src/pages/HomePage/HomePage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
-import BlogPostsCell from 'src/components/BlogPostsCell'
+import BlogLayout from "src/layouts/BlogLayout";
+import BlogPostsCell from "src/components/BlogPostsCell";
 
 const HomePage = () => {
-  return (
-    <BlogLayout>
-      <BlogPostsCell />
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<BlogPostsCell />
+		</BlogLayout>
+	);
+};
 
-export default HomePage
+export default HomePage;
 ```
 
 The browser should actually show an array with a number or two (assuming you created a blog post with our [scaffolding](./getting-dynamic#creating-a-post-editor) from earlier). Neat!
@@ -184,19 +184,19 @@ The browser should actually show an array with a number or two (assuming you cre
 
 In addition to the `id` that was added to the `query` by the generator, let's get the title, body, and createdAt too:
 
-```javascript{7-9}
+```javascript {7-9}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
 export const QUERY = gql`
-  query BlogPostsQuery {
-    posts {
-      id
-      title
-      body
-      createdAt
-    }
-  }
-`
+	query BlogPostsQuery {
+		posts {
+			id
+			title
+			body
+			createdAt
+		}
+	}
+`;
 ```
 
 The page should now show a dump of all the data you created for any blog posts you scaffolded:
@@ -205,20 +205,20 @@ The page should now show a dump of all the data you created for any blog posts y
 
 Now we're in the realm of good ol' React components, so just build out the `Success` component to display the blog post in a nicer format:
 
-```javascript{4-12}
+```javascript {4-12}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
 export const Success = ({ posts }) => {
-  return posts.map((post) => (
-    <article key={post.id}>
-      <header>
-        <h2>{post.title}</h2>
-      </header>
-      <p>{post.body}</p>
-      <div>Posted at: {post.createdAt}</div>
-    </article>
-  ))
-}
+	return posts.map((post) => (
+		<article key={post.id}>
+			<header>
+				<h2>{post.title}</h2>
+			</header>
+			<p>{post.body}</p>
+			<div>Posted at: {post.createdAt}</div>
+		</article>
+	));
+};
 ```
 
 And just like that we have a blog! It may be the most basic, ugly blog that ever graced the internet, but it's something! (Don't worry, we've got more features to add.)

--- a/docs/tutorial/deployment.md
+++ b/docs/tutorial/deployment.md
@@ -24,7 +24,7 @@ Before we continue, make sure your app is fully committed and pushed to GitHub, 
 
 > **NOTE:** Git initializes with `master`. Don't know how to rename `master` to `main`? If you're pushing to GitHub, you can follow these steps:
 >
-> ```plaintext{4,6}
+> ```plaintext {4,6}
 > git init
 > git add .
 > git commit -m 'First commit'

--- a/docs/tutorial/everyones-favorite-thing-to-build-forms.md
+++ b/docs/tutorial/everyones-favorite-thing-to-build-forms.md
@@ -22,49 +22,49 @@ Let's build the simplest form that still makes sense for our blog, a "contact us
 
 We can put a link to Contact in our layout's header:
 
-```javascript{17-19}
+```javascript {17-19}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const BlogLayout = ({ children }) => {
-  return (
-    <>
-      <header>
-        <h1>
-          <Link to={routes.home()}>Redwood Blog</Link>
-        </h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-            <li>
-              <Link to={routes.contact()}>Contact</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>{children}</main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>
+					<Link to={routes.home()}>Redwood Blog</Link>
+				</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+						<li>
+							<Link to={routes.contact()}>Contact</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>{children}</main>
+		</>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 And then use the `BlogLayout` in the `ContactPage`:
 
-```javascript{3,6}
+```javascript {3,6}
 // web/src/pages/ContactPage/ContactPage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  return <BlogLayout></BlogLayout>
-}
+	return <BlogLayout></BlogLayout>;
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 Double check that everything looks good and then let's get to the good stuff.
@@ -104,66 +104,66 @@ textarea.error {
 
 For now we won't be talking to the database in our Contact form so we won't create a cell. Let's create the form right on the page. Redwood forms start with the...wait for it...`<Form>` tag:
 
-```javascript{3,9}
+```javascript {3,9}
 // web/src/pages/ContactPage/ContactPage.js
 
-import { Form } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  return (
-    <BlogLayout>
-      <Form></Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form></Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 Well that was anticlimactic. You can't even see it in the browser. Let's add a form field so we can at least see something. Redwood ships with several inputs and a plain text input box is `<TextField>`. We'll also give the field a `name` attribute so that once there are multiple inputs on this page we'll know which contains which data:
 
-```javascript{3,10}
+```javascript {3,10}
 // web/src/pages/ContactPage/ContactPage.js
 
-import { Form, TextField } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  return (
-    <BlogLayout>
-      <Form>
-        <TextField name="input" />
-      </Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form>
+				<TextField name="input" />
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258121-4f4d2300-8637-11ea-83f5-c667e05aaf74.png" />
 
 Something is showing! Still, pretty boring. How about adding a submit button?
 
-```javascript{3,11}
+```javascript {3,11}
 // web/src/pages/ContactPage/ContactPage.js
 
-import { Form, TextField, Submit } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, Submit } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  return (
-    <BlogLayout>
-      <Form>
-        <TextField name="input" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form>
+				<TextField name="input" />
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258188-7572c300-8637-11ea-9583-1b7636f93be0.png" />
@@ -174,23 +174,23 @@ We have what might actually be considered a real, bonafide form here. Try typing
 
 Similar to a plain HTML form we'll give `<Form>` an `onSubmit` handler. That handler will be called with a single argument—an object containing all of the submitted form fields:
 
-```javascript{4-6,10}
+```javascript {4-6,10}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
-  const onSubmit = (data) => {
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <TextField name="input" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form onSubmit={onSubmit}>
+				<TextField name="input" />
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 ```
 
 Now try filling in some data and submitting:
@@ -199,30 +199,30 @@ Now try filling in some data and submitting:
 
 Great! Let's turn this into a more useful form by adding a couple fields. We'll rename the existing one to "name" and add "email" and "message":
 
-```javascript{3,15,16}
+```javascript {3,15,16}
 // web/src/pages/ContactPage/ContactPage.js
 
-import { Form, TextField, TextAreaField, Submit } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, TextAreaField, Submit } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  const onSubmit = (data) => {
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <TextField name="name" />
-        <TextField name="email" />
-        <TextAreaField name="message" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form onSubmit={onSubmit}>
+				<TextField name="name" />
+				<TextField name="email" />
+				<TextAreaField name="message" />
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 See the new `<TextAreaField>` component here which generates an HTML `<textarea>` but that contains Redwood's form goodness:
@@ -231,25 +231,25 @@ See the new `<TextAreaField>` component here which generates an HTML `<textarea>
 
 Let's add some labels:
 
-```javascript{6,9,12}
+```javascript {6,9,12}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258431-15c8e780-8638-11ea-8eca-0bd222b51d8a.png" />
@@ -262,25 +262,25 @@ Try filling out the form and submitting and you should get a console message wit
 
 All three of these fields should be required in order for someone to send a message to us. Let's enforce that with the standard HTML `required` attribute:
 
-```javascript{7,10,13}
+```javascript {7,10,13}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" required />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" required />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" required />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" required />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" required />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" required />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258542-5163b180-8638-11ea-8450-8a727de177ad.png" />
@@ -289,25 +289,25 @@ Now when trying to submit there'll be message from the browser noting that a fie
 
 Yes! Let's update that `required` call to instead be an object we pass to a custom attribute on Redwood form helpers called `validation`:
 
-```javascript{7,10,13}
+```javascript {7,10,13}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" validation={{ required: true }} />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" validation={{ required: true }} />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" validation={{ required: true }} />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" validation={{ required: true }} />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" validation={{ required: true }} />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" validation={{ required: true }} />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 And now when we submit the form with blank fields...the Name field gets focus. Boring. But this is just a stepping stone to our amazing reveal! We have one more form helper component to add—the one that displays errors on a field. Oh, it just so happens that it's plain HTML so we can style it however we want!
@@ -316,45 +316,39 @@ And now when we submit the form with blank fields...the Name field gets focus. B
 
 Introducing `<FieldError>` (don't forget to include it in the `import` statement at the top):
 
-```javascript{8,22,26,30}
+```javascript {8,22,26,30}
 // web/src/pages/ContactPage/ContactPage.js
 
-import {
-  Form,
-  TextField,
-  TextAreaField,
-  Submit,
-  FieldError,
-} from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, TextAreaField, Submit, FieldError } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  const onSubmit = (data) => {
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <label htmlFor="name">Name</label>
-        <TextField name="name" validation={{ required: true }} />
-        <FieldError name="name" />
+	return (
+		<BlogLayout>
+			<Form onSubmit={onSubmit}>
+				<label htmlFor="name">Name</label>
+				<TextField name="name" validation={{ required: true }} />
+				<FieldError name="name" />
 
-        <label htmlFor="email">Email</label>
-        <TextField name="email" validation={{ required: true }} />
-        <FieldError name="email" />
+				<label htmlFor="email">Email</label>
+				<TextField name="email" validation={{ required: true }} />
+				<FieldError name="email" />
 
-        <label htmlFor="message">Message</label>
-        <TextAreaField name="message" validation={{ required: true }} />
-        <FieldError name="message" />
+				<label htmlFor="message">Message</label>
+				<TextAreaField name="message" validation={{ required: true }} />
+				<FieldError name="message" />
 
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 Note that the `name` attribute matches the `name` of the input field above it. That's so it knows which field to display errors for. Try submitting that form now.
@@ -363,132 +357,101 @@ Note that the `name` attribute matches the `name` of the input field above it. T
 
 But this is just the beginning. Let's make sure folks realize this is an error message. Remember the `.error` class we defined in `index.css`? Check out the `className` attribute on `<FieldError>`:
 
-```javascript{8,12,16}
+```javascript {8,12,16}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" validation={{ required: true }} />
-      <FieldError name="name" className="error" />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" validation={{ required: true }} />
+			<FieldError name="name" className="error" />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" validation={{ required: true }} />
-      <FieldError name="email" className="error" />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" validation={{ required: true }} />
+			<FieldError name="email" className="error" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" validation={{ required: true }} />
-      <FieldError name="message" className="error" />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" validation={{ required: true }} />
+			<FieldError name="message" className="error" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 <img src="https://user-images.githubusercontent.com/300/73306040-3cf65100-41d0-11ea-99a9-9468bba82da7.png" />
 
 You know what would be nice? If the input itself somehow displayed the fact that there was an error. Check out the `errorClassName` attributes on the inputs:
 
-```javascript{10,18,26}
+```javascript {10,18,26}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField
-        name="name"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="name" className="error" />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" validation={{ required: true }} errorClassName="error" />
+			<FieldError name="name" className="error" />
 
-      <label htmlFor="email">Email</label>
-      <TextField
-        name="email"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="email" className="error" />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" validation={{ required: true }} errorClassName="error" />
+			<FieldError name="email" className="error" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField
-        name="message"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="message" className="error" />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" validation={{ required: true }} errorClassName="error" />
+			<FieldError name="message" className="error" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258907-39d8f880-8639-11ea-8816-03a11c69e8ac.png" />
 
 Oooo, what if the _label_ could change as well? It can, but we'll need Redwood's custom `<Label>` component for that. Note that the `for` attribute of `<label>` becomes the `name` prop on `<Label>`, just like with the other Redwood form components. And don't forget the import:
 
-```javascript{9,21-23,31-33,41-43}
+```javascript {9,21-23,31-33,41-43}
 // web/src/pages/ContactPage/ContactPage.js
 
-import {
-  Form,
-  TextField,
-  TextAreaField,
-  Submit,
-  FieldError,
-  Label,
-} from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, TextAreaField, Submit, FieldError, Label } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  const onSubmit = (data) => {
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <Label name="name" errorClassName="error">
-          Name
-        </Label>
-        <TextField
-          name="name"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="name" className="error" />
+	return (
+		<BlogLayout>
+			<Form onSubmit={onSubmit}>
+				<Label name="name" errorClassName="error">
+					Name
+				</Label>
+				<TextField name="name" validation={{ required: true }} errorClassName="error" />
+				<FieldError name="name" className="error" />
 
-        <Label name="email" errorClassName="error">
-          Email
-        </Label>
-        <TextField
-          name="email"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="email" className="error" />
+				<Label name="email" errorClassName="error">
+					Email
+				</Label>
+				<TextField name="email" validation={{ required: true }} errorClassName="error" />
+				<FieldError name="email" className="error" />
 
-        <Label name="message" errorClassName="error">
-          Message
-        </Label>
-        <TextAreaField
-          name="message"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="message" className="error" />
+				<Label name="message" errorClassName="error">
+					Message
+				</Label>
+				<TextAreaField name="message" validation={{ required: true }} errorClassName="error" />
+				<FieldError name="message" className="error" />
 
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80259003-70af0e80-8639-11ea-97cf-b6b816118fbf.png" />
@@ -501,37 +464,16 @@ export default ContactPage
 
 We should make sure the email field actually contains an email:
 
-```html{7-9}
-// web/src/pages/ContactPage/ContactPage.js
-
-<TextField
-  name="email"
-  validation={{
-    required: true,
-    pattern: {
-      value: /[^@]+@[^.]+\..+/,
-    },
-  }}
-  errorClassName="error"
-/>
+```html {7-9}
+// web/src/pages/ContactPage/ContactPage.js <TextField name="email" validation={{ required: true, pattern: { value:
+/[^@]+@[^.]+\..+/, }, }} errorClassName="error" />
 ```
 
 That is definitely not the end-all-be-all for email address validation, but pretend it's bulletproof. Let's also change the message on the email validation to be a little more friendly:
 
-```html{9}
-// web/src/pages/ContactPage/ContactPage.js
-
-<TextField
-  name="email"
-  validation={{
-    required: true,
-    pattern: {
-      value: /[^@]+@[^.]+\..+/,
-      message: 'Please enter a valid email address',
-    },
-  }}
-  errorClassName="error"
-/>
+```html {9}
+// web/src/pages/ContactPage/ContactPage.js <TextField name="email" validation={{ required: true, pattern: { value:
+/[^@]+@[^.]+\..+/, message: 'Please enter a valid email address', }, }} errorClassName="error" />
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80259139-bd92e500-8639-11ea-99d5-be278dc67afc.png" />

--- a/docs/tutorial/getting-dynamic.md
+++ b/docs/tutorial/getting-dynamic.md
@@ -27,7 +27,7 @@ We use [Prisma Client JS](https://github.com/prisma/prisma-client-js) to talk to
 
 First let's define the data structure for a post in the database. Open up `api/db/schema.prisma` and add the definition of our Post table (remove any "sample" models that are present in the file). Once you're done the entire schema file should look like:
 
-```plaintext{13-18}
+```plaintext {13-18}
 // api/db/schema.prisma
 
 datasource DS {

--- a/docs/tutorial/layouts.md
+++ b/docs/tutorial/layouts.md
@@ -22,65 +22,62 @@ That created `web/src/layouts/BlogLayout/BlogLayout.js` and an associated test f
 
 Cut the `<header>` from both `HomePage` and `AboutPage` and paste it in the layout instead. Let's take out the duplicated `<main>` tag as well:
 
-```javascript{3,7-19}
+```javascript {3,7-19}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const BlogLayout = ({ children }) => {
-  return (
-    <>
-      <header>
-        <h1>Redwood Blog</h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>{children}</main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>Redwood Blog</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>{children}</main>
+		</>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 `children` is where the magic will happen. Any page content given to the layout will be rendered here. Back to `HomePage` and `AboutPage`, we add a `<BlogLayout>` wrapper and now they're back to focusing on the content they care about (we can remove the import for `Link` and `routes` from `HomePage` since those are in the Layout instead):
 
-```javascript{3,6}
+```javascript {3,6}
 // web/src/pages/HomePage/HomePage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
+import BlogLayout from "src/layouts/BlogLayout";
 
 const HomePage = () => {
-  return <BlogLayout>Home</BlogLayout>
-}
+	return <BlogLayout>Home</BlogLayout>;
+};
 
-export default HomePage
+export default HomePage;
 ```
 
-```javascript{4,8-14}
+```javascript {4,8-14}
 // web/src/pages/AboutPage/AboutPage.js
 
-import { Link, routes } from '@redwoodjs/router'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Link, routes } from "@redwoodjs/router";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const AboutPage = () => {
-  return (
-    <BlogLayout>
-      <p>
-        This site was created to demonstrate my mastery of Redwood: Look on my
-        works, ye mighty, and despair!
-      </p>
-      <Link to={routes.home()}>Return home</Link>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<p>This site was created to demonstrate my mastery of Redwood: Look on my works, ye mighty, and despair!</p>
+			<Link to={routes.home()}>Return home</Link>
+		</BlogLayout>
+	);
+};
 
-export default AboutPage
+export default AboutPage;
 ```
 
 > **The `src` alias**
@@ -103,32 +100,32 @@ Back to the browser and you should see...nothing different. But that's good, it 
 
 One more `<Link>`, let's have the title/logo link back to the homepage as per usual:
 
-```javascript{9-11}
+```javascript {9-11}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const BlogLayout = ({ children }) => {
-  return (
-    <>
-      <header>
-        <h1>
-          <Link to={routes.home()}>Redwood Blog</Link>
-        </h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>{children}</main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>
+					<Link to={routes.home()}>Redwood Blog</Link>
+				</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>{children}</main>
+		</>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 And then we can remove the extra "Return to Home" link (and Link/routes import) that we had on the About page:

--- a/docs/tutorial/routing-params.md
+++ b/docs/tutorial/routing-params.md
@@ -12,26 +12,26 @@ Now that we have our homepage listing all the posts, let's build the "detail" pa
 
 Now let's link the title of the post on the homepage to the detail page (and include the `import` for `Link` and `routes`):
 
-```javascript{3,12}
+```javascript {3,12}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 // QUERY, Loading, Empty and Failure definitions...
 
 export const Success = ({ posts }) => {
-  return posts.map((post) => (
-    <article key={post.id}>
-      <header>
-        <h2>
-          <Link to={routes.blogPost()}>{post.title}</Link>
-        </h2>
-      </header>
-      <p>{post.body}</p>
-      <div>Posted at: {post.createdAt}</div>
-    </article>
-  ))
-}
+	return posts.map((post) => (
+		<article key={post.id}>
+			<header>
+				<h2>
+					<Link to={routes.blogPost()}>{post.title}</Link>
+				</h2>
+			</header>
+			<p>{post.body}</p>
+			<div>Posted at: {post.createdAt}</div>
+		</article>
+	));
+};
 ```
 
 If you click the link on the title of the blog post you should see the boilerplate text on `BlogPostPage`. But what we really need is to specify _which_ post we want to view on this page. It would be nice to be able to specify the ID of the post in the URL with something like `/blog-post/1`. Let's tell the `<Route>` to expect another part of the URL, and when it does, give that part a name that we can reference later:
@@ -81,43 +81,43 @@ export default BlogPostPage;
 
 Now over to the cell, we need access to that `{id}` route param so we can look up the ID of the post in the database. Let's update the query to accept a variable (and again change the query name from `blogPost` to just `post`)
 
-```javascript{4,5,7-9,20,21}
+```javascript {4,5,7-9,20,21}
 // web/src/components/BlogPostCell/BlogPostCell.js
 
 export const QUERY = gql`
-  query BlogPostQuery($id: Int!) {
-    post(id: $id) {
-      id
-      title
-      body
-      createdAt
-    }
-  }
-`
+	query BlogPostQuery($id: Int!) {
+		post(id: $id) {
+			id
+			title
+			body
+			createdAt
+		}
+	}
+`;
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <div>Loading...</div>;
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <div>Empty</div>;
 
-export const Failure = ({ error }) => <div>Error: {error.message}</div>
+export const Failure = ({ error }) => <div>Error: {error.message}</div>;
 
 export const Success = ({ post }) => {
-  return JSON.stringify(post)
-}
+	return JSON.stringify(post);
+};
 ```
 
 Okay, we're getting closer. Still, where will that `$id` come from? Redwood has another trick up its sleeve. Whenever you put a route param in a route, that param is automatically made available to the page that route renders. Which means we can update `BlogPostPage` to look like this:
 
-```javascript{3,6}
+```javascript {3,6}
 // web/src/pages/BlogPostPage/BlogPostPage.js
 
 const BlogPostPage = ({ id }) => {
-  return (
-    <BlogLayout>
-      <BlogPostCell id={id} />
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<BlogPostCell id={id} />
+		</BlogLayout>
+	);
+};
 ```
 
 `id` already exists since we named our route param `{id}`. Thanks Redwood! But how does that `id` end up as the `$id` GraphQL parameter? If you've learned anything about Redwood by now, you should know it's going to take care of that for you! By default, any props you give to a cell will automatically be turned into variables and given to the query. "Say what!" you're saying. It's true!
@@ -193,51 +193,51 @@ export default BlogPost;
 
 Let's take the post display code out of `BlogPostsCell` and put it here instead, taking the `post` in as a prop:
 
-```javascript{3,5,7-14}
+```javascript {3,5,7-14}
 // web/src/components/BlogPost/BlogPost.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const BlogPost = ({ post }) => {
-  return (
-    <article>
-      <header>
-        <h2>
-          <Link to={routes.blogPost({ id: post.id })}>{post.title}</Link>
-        </h2>
-      </header>
-      <div>{post.body}</div>
-    </article>
-  )
-}
+	return (
+		<article>
+			<header>
+				<h2>
+					<Link to={routes.blogPost({ id: post.id })}>{post.title}</Link>
+				</h2>
+			</header>
+			<div>{post.body}</div>
+		</article>
+	);
+};
 
-export default BlogPost
+export default BlogPost;
 ```
 
 And update `BlogPostsCell` and `BlogPostCell` to use this new component instead:
 
-```javascript{3,8}
+```javascript {3,8}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
-import BlogPost from 'src/components/BlogPost'
+import BlogPost from "src/components/BlogPost";
 
 // Loading, Empty, Failure...
 
 export const Success = ({ posts }) => {
-  return posts.map((post) => <BlogPost key={post.id} post={post} />)
-}
+	return posts.map((post) => <BlogPost key={post.id} post={post} />);
+};
 ```
 
-```javascript{3,8}
+```javascript {3,8}
 // web/src/components/BlogPostCell/BlogPostCell.js
 
-import BlogPost from 'src/components/BlogPost'
+import BlogPost from "src/components/BlogPost";
 
 // Loading, Empty, Failure...
 
 export const Success = ({ post }) => {
-  return <BlogPost post={post} />
-}
+	return <BlogPost post={post} />;
+};
 ```
 
 And there we go! We should be able to move back and forth between the homepage and the detail page.

--- a/docs/tutorial/saving-data.md
+++ b/docs/tutorial/saving-data.md
@@ -86,56 +86,56 @@ As described in [Side Quest: How Redwood Deals with Data](side-quest-how-redwood
 
 In this case we're creating a single `Mutation` that we'll call `createContact`. Add that to the end of the SDL file (before the closing backtick):
 
-```javascript{28-30}
+```javascript {28-30}
 // api/src/graphql/contacts.sdl.js
 
 export const schema = gql`
-  type Contact {
-    id: Int!
-    name: String!
-    email: String!
-    message: String!
-    createdAt: DateTime!
-  }
+	type Contact {
+		id: Int!
+		name: String!
+		email: String!
+		message: String!
+		createdAt: DateTime!
+	}
 
-  type Query {
-    contacts: [Contact!]!
-  }
+	type Query {
+		contacts: [Contact!]!
+	}
 
-  input CreateContactInput {
-    name: String!
-    email: String!
-    message: String!
-  }
+	input CreateContactInput {
+		name: String!
+		email: String!
+		message: String!
+	}
 
-  input UpdateContactInput {
-    name: String
-    email: String
-    message: String
-  }
+	input UpdateContactInput {
+		name: String
+		email: String
+		message: String
+	}
 
-  type Mutation {
-    createContact(input: CreateContactInput!): Contact
-  }
-`
+	type Mutation {
+		createContact(input: CreateContactInput!): Contact
+	}
+`;
 ```
 
 The `createContact` mutation will accept a single variable, `input`, that is an object that conforms to what we expect for a `CreateContactInput`, namely `{ name, email, message }`.
 
 That's it for the SDL file, let's define the service that will actually save the data to the database. The service includes a default `contacts` function for getting all contacts from the database. Let's add our mutation to create a new contact:
 
-```javascript{9-11}
+```javascript {9-11}
 // api/src/services/contacts/contacts.js
 
-import { db } from 'src/lib/db'
+import { db } from "src/lib/db";
 
 export const contacts = () => {
-  return db.contact.findMany()
-}
+	return db.contact.findMany();
+};
 
 export const createContact = ({ input }) => {
-  return db.contact.create({ data: input })
-}
+	return db.contact.create({ data: input });
+};
 ```
 
 Thanks to Prisma Client JS it takes very little code to actually save something to the database! This is an asynchronous call but we didn't have to worry about resolving Promises or dealing with `async/await`. Apollo will do that for us!
@@ -180,7 +180,7 @@ We reference the `createContact` mutation we defined in the Contacts SDL passing
 
 Next we'll call the `useMutation` hook provided by Apollo which will allow us to execute the mutation when we're ready (don't forget the `import` statement):
 
-```javascript{11,15}
+```javascript {11,15}
 // web/src/pages/ContactPage/ContactPage.js
 
 import {
@@ -223,7 +223,7 @@ If you'll recall `<Form>` gives us all of the fields in a nice object where the 
 
 Now we can update the `onSubmit` function to invoke the mutation with the data it receives:
 
-```javascript{7}
+```javascript {7}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
@@ -254,7 +254,7 @@ Let's address these issues.
 
 The `useMutation` hook returns a couple more elements along with the function to invoke it. We can destructure these as the second element in the array that's returned. The two we care about are `loading` and `error`:
 
-```javascript{4}
+```javascript {4}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
@@ -271,14 +271,14 @@ const ContactPage = () => {
 
 Now we know if the database call is still in progress by looking at `loading`. An easy fix for our multiple submit issue would be to disable the submit button if the response is still in progress. We can set the `disabled` attribute on the "Save" button to the value of `loading`:
 
-```javascript{5}
+```javascript {5}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  // ...
-  <Submit disabled={loading}>Save</Submit>
-  // ...
-)
+	// ...
+	<Submit disabled={loading}>Save</Submit>
+	// ...
+);
 ```
 
 It may be hard to see a difference in development because the submit is so fast, but you could enable network throttling via the Network tab Chrome's Web Inspector to simulate a slow connection:
@@ -289,7 +289,7 @@ You'll see that the "Save" button become disabled for a second or two while wait
 
 Next, let's use Redwood's `Flash` system to let the user know their submission was successful. `useMutation` accepts an options object as a second argument. One of the options is a callback function, `onCompleted`, that will be invoked when the mutation successfully completes. We'll use that callback to add a message for the `Flash` component to display. Add the `Flash` component to the page and use the `timeout` prop to schedule the message's dismissal. ([Read the full documentation about Redwood's Flash system](https://redwoodjs.com/docs/flash-messaging-bus).)
 
-```javascript{4,10,13-17,24}
+```javascript {4,10,13-17,24}
 // web/src/pages/ContactPage/ContactPage.js
 
 // ...
@@ -331,38 +331,38 @@ We have email validation on the client, but any good developer knows [_never tru
 
 We talked about business logic belonging in our services files and this is a perfect example. Let's add a `validate` function to our `contacts` service:
 
-```javascript{3,7-15,22}
+```javascript {3,7-15,22}
 // api/src/services/contacts/contacts.js
 
-import { UserInputError } from '@redwoodjs/api'
+import { UserInputError } from "@redwoodjs/api";
 
-import { db } from 'src/lib/db'
+import { db } from "src/lib/db";
 
 const validate = (input) => {
-  if (input.email && !input.email.match(/[^@]+@[^.]+\..+/)) {
-    throw new UserInputError("Can't create new contact", {
-      messages: {
-        email: ['is not formatted like an email address'],
-      },
-    })
-  }
-}
+	if (input.email && !input.email.match(/[^@]+@[^.]+\..+/)) {
+		throw new UserInputError("Can't create new contact", {
+			messages: {
+				email: ["is not formatted like an email address"],
+			},
+		});
+	}
+};
 
 export const contacts = () => {
-  return db.contact.findMany()
-}
+	return db.contact.findMany();
+};
 
 export const createContact = ({ input }) => {
-  validate(input)
-  return db.contact.create({ data: input })
-}
+	validate(input);
+	return db.contact.create({ data: input });
+};
 ```
 
 So when `createContact` is called it will first validate the inputs and only if no errors are thrown will it continue to actually create the record in the database.
 
 We already capture any existing error in the `error` constant that we got from `useMutation`, so we _could_ manually display an error box on the page somewhere containing those errors, maybe at the top of the form:
 
-```html{4-9}
+```html {4-9}
 // web/src/pages/ContactPage/ContactPage.js
 
 <Form onSubmit={onSubmit} validation={{ mode: 'onBlur' }}>
@@ -377,16 +377,16 @@ We already capture any existing error in the `error` constant that we got from `
 
 > If you need to handle your errors manually, you can do this:
 >
-> ```javascript{3-8}
+> ```javascript {3-8}
 > // web/src/pages/ContactPage/ContactPage.js
 > const onSubmit = async (data) => {
->   try {
->     await create({ variables: { input: data } })
->     console.log(data)
->   } catch (error) {
->     console.log(error)
->   }
-> }
+> 	try {
+> 		await create({ variables: { input: data } });
+> 		console.log(data);
+> 	} catch (error) {
+> 		console.log(error);
+> 	}
+> };
 > ```
 
 To get a server error to fire, let's remove the email format validation so that the client-side error isn't shown:
@@ -406,7 +406,7 @@ Remember when we said that `<Form>` had one more trick up its sleeve? Here it co
 
 Remove the inline error display we just added (`{ error && ...}`) and replace it with `<FormError>`, passing the `error` constant we got from `useMutation` and a little bit of styling to `wrapperStyle` (don't forget the `import`). We'll also pass `error` to `<Form>` so it can setup a context:
 
-```javascript{10,18-22}
+```javascript {10,18-22}
 // web/src/pages/ContactPage/ContactPage.js
 
 import {
@@ -465,7 +465,7 @@ import { useForm } from "react-hook-form";
 
 And now call it inside of our component:
 
-```javascript{4}
+```javascript {4}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
@@ -475,7 +475,7 @@ const ContactPage = () => {
 
 Finally we'll tell `<Form>` to use the `formMethods` we just instantiated instead of doing it itself:
 
-```javascript{10}
+```javascript {10}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (

--- a/to-upload/fr/a-second-page-and-a-link.md
+++ b/to-upload/fr/a-second-page-and-a-link.md
@@ -8,7 +8,7 @@ Ajoutons donc une page "About" à notre blog de manière à ce que personne n'ig
 
     yarn redwood generate page about
 
-Remarquez que nous n'avons pas spécifié de chemin cette fois-ci, uniquement le nom de la page. En effet, si vous ne le précisez pas, la commande `redwood generate page` créera une `Route` en lui donnant pour chemin le nom de la page préfixé par un slash `/`. Dans le cas présent, ce sera donc `/about`. 
+Remarquez que nous n'avons pas spécifié de chemin cette fois-ci, uniquement le nom de la page. En effet, si vous ne le précisez pas, la commande `redwood generate page` créera une `Route` en lui donnant pour chemin le nom de la page préfixé par un slash `/`. Dans le cas présent, ce sera donc `/about`.
 
 > **Fragmenter le code pour chaque page**
 >
@@ -16,30 +16,30 @@ Remarquez que nous n'avons pas spécifié de chemin cette fois-ci, uniquement le
 
 `http://localhost:8910/about` devrait maintenant pointer sur votre nouvelle page. Bien entendu, absolument personne ne va trouver cette page de votre blog en modifiant manuellement l'URL! Ajoutons donc un lien depuis la page d'accueil vers la page About, et vice-versa. Nous commencerons par créer un simple header et une barre de navigation dans `HomePage.js`:
 
-```javascript{3,7-19}
+```javascript {3,7-19}
 // web/src/pages/HomePage/HomePage.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const HomePage = () => {
-  return (
-    <>
-      <header>
-        <h1>Redwood Blog</h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>A Propos</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>Home</main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>Redwood Blog</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>A Propos</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>Home</main>
+		</>
+	);
+};
 
-export default HomePage
+export default HomePage;
 ```
 
 Remarquons ici plusieurs points :
@@ -49,45 +49,44 @@ Remarquons ici plusieurs points :
 
   `<Route path="/about" page={AboutPage} name="about" />`
 
-  Si vous n'aimez pas le nom que la commande `redwood generate` utilise pour votre route, vous pouvez parfaitement le changer dans le fichier `Routes.js`! Les routes nommées sont extrêmement utiles car, si vous désirez modifiez le chemin associé avec une route, il vous suffit de le modifier dans le fichier `Routes.js` et immédiatement tous les liens qui utilisent cette route pointerons au bon endroit. Vous pouvez également passer directement une chaîne de caractères à l'attribut `to`, mais alors vous ne bénéficiez plus de ce mécanisme bien utile. 
+  Si vous n'aimez pas le nom que la commande `redwood generate` utilise pour votre route, vous pouvez parfaitement le changer dans le fichier `Routes.js`! Les routes nommées sont extrêmement utiles car, si vous désirez modifiez le chemin associé avec une route, il vous suffit de le modifier dans le fichier `Routes.js` et immédiatement tous les liens qui utilisent cette route pointerons au bon endroit. Vous pouvez également passer directement une chaîne de caractères à l'attribut `to`, mais alors vous ne bénéficiez plus de ce mécanisme bien utile.
 
 ### Retour à la maison
 
 Une fois sur la page "About", nous n'avons aucun moyen de revenir en arrière. Pour y remédier, ajoutons également un lien à cet endroit:
 
-```javascript{3,7-25}
+```javascript {3,7-25}
 // web/src/pages/AboutPage/AboutPage.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const AboutPage = () => {
-  return (
-    <>
-      <header>
-        <h1>Redwood Blog</h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>
-        <p>
-          Ce site est créé avec pour seule intention de démontrer la puissance créative de Redwood! Oui, c'est très 
-          impressionant :D
-        </p>
-        <Link to={routes.home()}>Retour à la page d'accueil</Link>
-      </main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>Redwood Blog</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>
+				<p>
+					Ce site est créé avec pour seule intention de démontrer la puissance créative de Redwood! Oui, c'est très
+					impressionant :D
+				</p>
+				<Link to={routes.home()}>Retour à la page d'accueil</Link>
+			</main>
+		</>
+	);
+};
 
-export default AboutPage
+export default AboutPage;
 ```
 
 Bien! Affichons cette page dans le navigateur and vérifions que nous pouvons aller et venir entre les différentes pages.
 
 En tant que développeur de classe cosmique, vous avez probablement repéré ce copier-coller un peu lourd du `<header>`. Nous aussi. C'est la raison pour laquelle Redwood dispose d'un petite chose bien pratique appelé "_Layout_"."
-

--- a/to-upload/fr/authentication.md
+++ b/to-upload/fr/authentication.md
@@ -4,7 +4,7 @@ title: "Authentification"
 sidebar_label: "Authentification"
 ---
 
-"Authentification" est un mot-valise pour tout ce qui se rapporte au fait de s'assurer que l'utilisateur, souvent identifié à l'aide d'un couple email/mot de passe, est autorisé à accéder à quelque chose. L'authentification peut être parfois [délicate à mettre en oeuvre](https://www.rdegges.com/2017/authentication-still-sucks/) techniquement et vous causer de sérieux maux de tête. 
+"Authentification" est un mot-valise pour tout ce qui se rapporte au fait de s'assurer que l'utilisateur, souvent identifié à l'aide d'un couple email/mot de passe, est autorisé à accéder à quelque chose. L'authentification peut être parfois [délicate à mettre en oeuvre](https://www.rdegges.com/2017/authentication-still-sucks/) techniquement et vous causer de sérieux maux de tête.
 
 Heureusement, Redwood est là pour vous! L'authentification n'est pas une chose qu'il vous faut écrire en partant de zero, c'est un problème identifié et résolu qui ne devrait au contraire vous causer que peu de soucis. A ce jour, Redwood s'intégre avec :
 
@@ -15,15 +15,15 @@ Puisque nous avons déjà commecé à déployer notre application sur Netlify, n
 
 > Il existe deux termes contenant beaucoup de lettres, commençant par "A" et finissant par "ation" qu'il bien faut distinguer:
 >
-> * Authentification (__Authentication__ en anglais)
-> * Autorisation (__Authorization__ en anglais)
+> - Authentification (**Authentication** en anglais)
+> - Autorisation (**Authorization** en anglais)
 >
 > Voici comment Redwood utilise ces termes:
 >
-> * **Authentification** se rapporte au fait de savoir dans quelle mesure une personne est bien celle qu'elle prétend être. Celà prend généralement la forme d'un formulaire de Login avec un email et un mot de passe, ou un fournisseurs OAuth tiers comme Google.
-> * **Autorisation** se rapporte au fait de savoir si un utilisateur (qui en général s'est déjà authentifié) est autorisé à effectuer ou non une action. Celà recouvre en général une combinaison de roles et de permissions qui sont évaluées avant de donner ou refuser l'accès à une URL du site.
+> - **Authentification** se rapporte au fait de savoir dans quelle mesure une personne est bien celle qu'elle prétend être. Celà prend généralement la forme d'un formulaire de Login avec un email et un mot de passe, ou un fournisseurs OAuth tiers comme Google.
+> - **Autorisation** se rapporte au fait de savoir si un utilisateur (qui en général s'est déjà authentifié) est autorisé à effectuer ou non une action. Celà recouvre en général une combinaison de roles et de permissions qui sont évaluées avant de donner ou refuser l'accès à une URL du site.
 >
-> Cette section du didacticiel se concentre en particulier sur l'**authentification**. Nous travaillons actuellement à inclure un système simple et flexible de rôles. Une fois ceci réalisé, nous mettrons à jour ce didacticiel! 
+> Cette section du didacticiel se concentre en particulier sur l'**authentification**. Nous travaillons actuellement à inclure un système simple et flexible de rôles. Une fois ceci réalisé, nous mettrons à jour ce didacticiel!
 
 ### Netlify Identity Setup
 
@@ -44,11 +44,12 @@ Quelques modifications doivent être effectuées sur le code pour mettre en plac
 ```terminal
 yarn rw g auth netlify
 ```
+
 Cette commande permet d'ajouter un fichier et d'en modifier quelques autres.
 
 > Vous ne remarquez aucun changement?
 >
-> Afin que celà fonctionne, vous devez utiliser au minimum la version `0.7.0` de Redwood. 
+> Afin que celà fonctionne, vous devez utiliser au minimum la version `0.7.0` de Redwood.
 > Le cas échéant, [mettez à jour Redwood](https://redwoodjs.com/docs/cli-commands#upgrade) avec `yarn rw upgrade`.
 
 Observez le contenu du fichier `api/src/lib/auth.js` qui vient d'être créé (les commentaires ont été supprimé pour plus de clarté):
@@ -75,8 +76,8 @@ Par défaut, le système d'authentification va retourner uniquement les données
 
 Les fichiers qui ont été modifés par le générateur sont les suivants:
 
-* `web/src/index.js`— Entoure le routeur au sein du composant `<AuthProvider>`, ce qui fait que les routes elle-mêmes sont soumises à authentification. Cela donne également accès au "hook" `useAuth()` qui expose quelques fonctions permettant à l'utilisateur de se connecter, se déconnecter, verifier le statut courant, etc.. 
-* `api/src/functions/graphql.js`— Rend disponible `currentUser` pour la partie API de l'application, de telle façon que vous puissez verifier si un utilisateur est autorisé ou non à faire quelque chose. Si vous ajoutez une implémentation à `getCurrentUser()` dans `api/src/lib/auth.js`, alors ce sera ce qui sera retourné par `currentUser`, dans le cas contraire `currentUser` contiendra `null`.
+- `web/src/index.js`— Entoure le routeur au sein du composant `<AuthProvider>`, ce qui fait que les routes elle-mêmes sont soumises à authentification. Cela donne également accès au "hook" `useAuth()` qui expose quelques fonctions permettant à l'utilisateur de se connecter, se déconnecter, verifier le statut courant, etc..
+- `api/src/functions/graphql.js`— Rend disponible `currentUser` pour la partie API de l'application, de telle façon que vous puissez verifier si un utilisateur est autorisé ou non à faire quelque chose. Si vous ajoutez une implémentation à `getCurrentUser()` dans `api/src/lib/auth.js`, alors ce sera ce qui sera retourné par `currentUser`, dans le cas contraire `currentUser` contiendra `null`.
 
 Nous allons connecter les côtés Web et API ci-dessous pour nous assurer qu'un utilisateur ne fait que les choses qu'il est autorisé à faire.
 
@@ -84,47 +85,47 @@ Nous allons connecter les côtés Web et API ci-dessous pour nous assurer qu'un 
 
 Commençons par verrouiller l'API afin que nous puissions être sûrs que seuls les utilisateurs autorisés peuvent créer, mettre à jour et supprimer une publication. Ouvrez le service Post et ajoutons une vérification:
 
-```javascript{4,17,24,32}
+```javascript {4,17,24,32}
 // api/src/services/posts/posts.js
 
-import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
+import { db } from "src/lib/db";
+import { requireAuth } from "src/lib/auth";
 
 export const posts = () => {
-  return db.post.findMany()
-}
+	return db.post.findMany();
+};
 
 export const post = ({ id }) => {
-  return db.post.findOne({
-    where: { id },
-  })
-}
+	return db.post.findOne({
+		where: { id },
+	});
+};
 
 export const createPost = ({ input }) => {
-  requireAuth()
-  return db.post.create({
-    data: input,
-  })
-}
+	requireAuth();
+	return db.post.create({
+		data: input,
+	});
+};
 
 export const updatePost = ({ id, input }) => {
-  requireAuth()
-  return db.post.update({
-    data: input,
-    where: { id },
-  })
-}
+	requireAuth();
+	return db.post.update({
+		data: input,
+		where: { id },
+	});
+};
 
 export const deletePost = ({ id }) => {
-  requireAuth()
-  return db.post.delete({
-    where: { id },
-  })
-}
+	requireAuth();
+	return db.post.delete({
+		where: { id },
+	});
+};
 
 export const Post = {
-  user: (_obj, { root }) => db.post.findOne({ where: { id: root.id } }).user(),
-}
+	user: (_obj, { root }) => db.post.findOne({ where: { id: root.id } }).user(),
+};
 ```
 
 Essayez maintenant de créer, de modifier ou de supprimer un article de nos pages d'administration. Il ne se passe rien! Devrions-nous afficher une sorte de message d'erreur convivial? Dans ce cas, probablement pas - nous allons verrouiller complètement les pages d'administration afin qu'elles ne soient pas accessibles par un navigateur. La seule façon pour quelqu'un de déclencher ces erreurs dans l'API est de tenter d'accéder directement au point de terminaison GraphQL, sans passer par notre interface utilisateur. L'API renvoie déjà un message d'erreur (ouvrez l'inspecteur Web dans votre navigateur et essayez à nouveau de créer / modifier / supprimer), nous sommes donc couverts.
@@ -137,30 +138,30 @@ Essayez maintenant de créer, de modifier ou de supprimer un article de nos page
 
 Nous allons maintenant restreindre complètement l'accès aux pages d'administration, sauf si vous êtes connecté. La première étape consistera à indiquer les itinéraires qui nécessiteront que vous soyez connecté. Pour ce faire, ajouter la balise `<Private>`:
 
-```javascript{3,12,16}
+```javascript {3,12,16}
 // web/src/Routes.js
 
-import { Router, Route, Private } from '@redwoodjs/router'
+import { Router, Route, Private } from "@redwoodjs/router";
 
 const Routes = () => {
-  return (
-    <Router>
-      <Route path="/contact" page={ContactPage} name="contact" />
-      <Route path="/about" page={AboutPage} name="about" />
-      <Route path="/" page={HomePage} name="home" />
-      <Route path="/blog-post/{id:Int}" page={BlogPostPage} name="blogPost" />
-      <Private unauthenticated="home">
-        <Route path="/admin/posts/new" page={NewPostPage} name="newPost" />
-        <Route path="/admin/posts/{id:Int}/edit" page={EditPostPage} name="editPost" />
-        <Route path="/admin/posts/{id:Int}" page={PostPage} name="post" />
-        <Route path="/admin/posts" page={PostsPage} name="posts" />
-      </Private>
-      <Route notfound page={NotFoundPage} />
-    </Router>
-  )
-}
+	return (
+		<Router>
+			<Route path="/contact" page={ContactPage} name="contact" />
+			<Route path="/about" page={AboutPage} name="about" />
+			<Route path="/" page={HomePage} name="home" />
+			<Route path="/blog-post/{id:Int}" page={BlogPostPage} name="blogPost" />
+			<Private unauthenticated="home">
+				<Route path="/admin/posts/new" page={NewPostPage} name="newPost" />
+				<Route path="/admin/posts/{id:Int}/edit" page={EditPostPage} name="editPost" />
+				<Route path="/admin/posts/{id:Int}" page={PostPage} name="post" />
+				<Route path="/admin/posts" page={PostsPage} name="posts" />
+			</Private>
+			<Route notfound page={NotFoundPage} />
+		</Router>
+	);
+};
 
-export default Routes
+export default Routes;
 ```
 
 Entourez les routes que vous voulez protéger par l'authentification, et ajoutez éventuellement l'attribut `unauthenticated` qui répertorie le nom d'une autre route vers laquelle rediriger si l'utilisateur n'est pas connecté. Dans ce cas, nous reviendrons à la page d'accueil.
@@ -169,41 +170,41 @@ Essayez cela dans votre navigateur. Si vous cliquez sur http://localhost:8910/ad
 
 Il ne reste plus qu'à laisser l'utilisateur se connecter! Si vous avez déjà créé une authentification, vous savez que cette partie est généralement un frein, mais Redwood en fait une gentille promenade au parc. La majeure partie de la plomberie a été gérée par le générateur d'authentification, nous pouvons donc nous concentrer sur les parties que l'utilisateur voit réellement. Tout d'abord, ajoutons un lien **Login** qui déclenchera une fenêtre modale à partir du [widget Netlify Identity](https://github.com/netlify/netlify-identity-widget). Supposons que nous souhaitons obtenir cela sur toutes les pages publiques, nous allons donc le mettre dans le `BlogLayout`:
 
-```javascript{4,7,22-26}
+```javascript {4,7,22-26}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
-import { useAuth } from '@redwoodjs/auth'
+import { Link, routes } from "@redwoodjs/router";
+import { useAuth } from "@redwoodjs/auth";
 
 const BlogLayout = ({ children }) => {
-  const { logIn } = useAuth()
+	const { logIn } = useAuth();
 
-  return (
-    <div>
-      <h1>
-        <Link to={routes.home()}>Redwood Blog</Link>
-      </h1>
-      <nav>
-        <ul>
-          <li>
-            <Link to={routes.about()}>About</Link>
-          </li>
-          <li>
-            <Link to={routes.contact()}>Contact</Link>
-          </li>
-          <li>
-            <a href="#" onClick={logIn}>
-              Log In
-            </a>
-          </li>
-        </ul>
-      </nav>
-      <main>{children}</main>
-    </div>
-  )
-}
+	return (
+		<div>
+			<h1>
+				<Link to={routes.home()}>Redwood Blog</Link>
+			</h1>
+			<nav>
+				<ul>
+					<li>
+						<Link to={routes.about()}>About</Link>
+					</li>
+					<li>
+						<Link to={routes.contact()}>Contact</Link>
+					</li>
+					<li>
+						<a href="#" onClick={logIn}>
+							Log In
+						</a>
+					</li>
+				</ul>
+			</nav>
+			<main>{children}</main>
+		</div>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 Essayez de cliquer sur le lien Login:
@@ -228,87 +229,87 @@ Une fois que vous faites cela, la fenêtre modale devrait se mettre à jour et d
 
 Cependant, nous n'avons actuellement aucune indication sur notre site que nous sommes connectés. Pourquoi ne pas changer le bouton **Log In** en **Log Out** lorsque vous êtes authentifié:
 
-```javascript{7,23-24}
+```javascript {7,23-24}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
-import { useAuth } from '@redwoodjs/auth'
+import { Link, routes } from "@redwoodjs/router";
+import { useAuth } from "@redwoodjs/auth";
 
 const BlogLayout = ({ children }) => {
-  const { logIn, logOut, isAuthenticated } = useAuth()
+	const { logIn, logOut, isAuthenticated } = useAuth();
 
-  return (
-    <div>
-      <h1>
-        <Link to={routes.home()}>Redwood Blog</Link>
-      </h1>
-      <nav>
-        <ul>
-          <li>
-            <Link to={routes.about()}>About</Link>
-          </li>
-          <li>
-            <Link to={routes.contact()}>Contact</Link>
-          </li>
-          <li>
-            <a href="#" onClick={isAuthenticated ? logOut : logIn}>
-              {isAuthenticated ? 'Log Out' : 'Log In'}
-            </a>
-          </li>
-        </ul>
-      </nav>
-      <main>{children}</main>
-    </div>
-  )
-}
+	return (
+		<div>
+			<h1>
+				<Link to={routes.home()}>Redwood Blog</Link>
+			</h1>
+			<nav>
+				<ul>
+					<li>
+						<Link to={routes.about()}>About</Link>
+					</li>
+					<li>
+						<Link to={routes.contact()}>Contact</Link>
+					</li>
+					<li>
+						<a href="#" onClick={isAuthenticated ? logOut : logIn}>
+							{isAuthenticated ? "Log Out" : "Log In"}
+						</a>
+					</li>
+				</ul>
+			</nav>
+			<main>{children}</main>
+		</div>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
-`useAuth ()` nous apporte quelques aides supplémentaires, dans le cas présent `isAuthenticated` retournera` true` ou `false` en fonction de votre statut de connexion, et` logOut ()` déconnectera l'utilisateur. Cliquez maintenant sur **Log Out**  pour vous déconnecter et changer le lien en **Log In** sur lequel vous pouvez cliquer pour ouvrir la fenêtre modale et vous reconnecter.
+`useAuth ()` nous apporte quelques aides supplémentaires, dans le cas présent `isAuthenticated` retournera` true` ou `false` en fonction de votre statut de connexion, et` logOut ()` déconnectera l'utilisateur. Cliquez maintenant sur **Log Out** pour vous déconnecter et changer le lien en **Log In** sur lequel vous pouvez cliquer pour ouvrir la fenêtre modale et vous reconnecter.
 
-Lorsque vous *êtes* connecté, vous devriez pouvoir accéder à nouveau aux pages d'administration: http://localhost:8910/admin/posts
+Lorsque vous _êtes_ connecté, vous devriez pouvoir accéder à nouveau aux pages d'administration: http://localhost:8910/admin/posts
 
 > Si vous commencez à travailler sur une autre application Redwood qui utilise Netlify Identity, vous devrez effacer manuellement votre stockage local, où est stockée l'URL du site que vous avez entrée la première fois que vous avez vu la fenêtre modale. Le stockage local est lié à votre domaine et à votre port, qui par défaut seront les mêmes pour toute application Redwood lors du développement local. Vous pouvez effacer votre stockage local dans Chrome en allant dans l'inspecteur Web, puis dans l'onglet **Application**, puis à gauche, ouvrez **Local Storage** et cliquez sur http://localhost:8910. Vous verrez les clés stockées sur la droite et pourrez toutes les supprimer.
 
 Encore un détail: montrons l'adresse e-mail de l'utilisateur connecté. Nous pouvons obtenir le `currentUser` par le "hook" `useAuth()`. Il contiendra les données que notre bibliothèque d'authentification tierce stocke pour l'utilisateur actuellement connecté:
 
-```javascript{7,27}
+```javascript {7,27}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
-import { useAuth } from '@redwoodjs/auth'
+import { Link, routes } from "@redwoodjs/router";
+import { useAuth } from "@redwoodjs/auth";
 
 const BlogLayout = ({ children }) => {
-  const { logIn, logOut, isAuthenticated, currentUser } = useAuth()
+	const { logIn, logOut, isAuthenticated, currentUser } = useAuth();
 
-  return (
-    <div>
-      <h1>
-        <Link to={routes.home()}>Redwood Blog</Link>
-      </h1>
-      <nav>
-        <ul>
-          <li>
-            <Link to={routes.about()}>About</Link>
-          </li>
-          <li>
-            <Link to={routes.contact()}>Contact</Link>
-          </li>
-          <li>
-            <a href="#" onClick={isAuthenticated ? logOut : logIn}>
-              {isAuthenticated ? 'Log Out' : 'Log In'}
-            </a>
-          </li>
-          {isAuthenticated && <li>{currentUser.email}</li>}
-        </ul>
-      </nav>
-      <main>{children}</main>
-    </div>
-  )
-}
+	return (
+		<div>
+			<h1>
+				<Link to={routes.home()}>Redwood Blog</Link>
+			</h1>
+			<nav>
+				<ul>
+					<li>
+						<Link to={routes.about()}>About</Link>
+					</li>
+					<li>
+						<Link to={routes.contact()}>Contact</Link>
+					</li>
+					<li>
+						<a href="#" onClick={isAuthenticated ? logOut : logIn}>
+							{isAuthenticated ? "Log Out" : "Log In"}
+						</a>
+					</li>
+					{isAuthenticated && <li>{currentUser.email}</li>}
+				</ul>
+			</nav>
+			<main>{children}</main>
+		</div>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 ![Logged in email](https://user-images.githubusercontent.com/300/82389433-05b2e680-99f1-11ea-9d01-456cad508c80.png)
@@ -317,5 +318,4 @@ export default BlogLayout
 
 Croyez-le ou non, c'est tout! L'authentification avec Redwood est un jeu d'enfant et nous ne faisons que commencer. Attendez-vous à plus de magie bientôt!
 
-> Si vous inspectez le contenu de `currentUser`, vous verrez qu'il contient un tableau appelé `roles`. Sur le tableau de bord Netlify Identity, vous pouvez attribuer à votre utilisateur une collection de rôles, qui ne sont que des chaînes de caractères telles que «admin» ou «guest». En utilisant cette gamme de rôles, vous *pourriez* créer un système d'authentification basé sur les rôles très rudimentaire. À moins que vous n'ayez un besoin urgent de cette simple vérification de rôle, nous vous recommandons d'attendre la solution Redwood, à venir bientôt!
-
+> Si vous inspectez le contenu de `currentUser`, vous verrez qu'il contient un tableau appelé `roles`. Sur le tableau de bord Netlify Identity, vous pouvez attribuer à votre utilisateur une collection de rôles, qui ne sont que des chaînes de caractères telles que «admin» ou «guest». En utilisant cette gamme de rôles, vous _pourriez_ créer un système d'authentification basé sur les rôles très rudimentaire. À moins que vous n'ayez un besoin urgent de cette simple vérification de rôle, nous vous recommandons d'attendre la solution Redwood, à venir bientôt!

--- a/to-upload/fr/cells.md
+++ b/to-upload/fr/cells.md
@@ -10,32 +10,30 @@ Lorsque vous créez une nouvelle Cell, vous exportez quelques constantes, toujou
 
 ```javascript
 export const QUERY = gql`
-  query {
-    posts {
-      id
-      title
-      body
-      createdAt
-    }
-  }
-`
+	query {
+		posts {
+			id
+			title
+			body
+			createdAt
+		}
+	}
+`;
 
-export const Loading = () => <div>Chargement...</div>
+export const Loading = () => <div>Chargement...</div>;
 
-export const Empty = () => <div>Aucun article disponible!</div>
+export const Empty = () => <div>Aucun article disponible!</div>;
 
-export const Failure = ({ error }) => (
-  <div>Erreur lors du chargement des articles: {error.message}</div>
-)
+export const Failure = ({ error }) => <div>Erreur lors du chargement des articles: {error.message}</div>;
 
 export const Success = ({ posts }) => {
-  return posts.map((post) => (
-    <article>
-      <h2>{post.title}</h2>
-      <div>{post.body}</div>
-    </article>
-  ))
-}
+	return posts.map((post) => (
+		<article>
+			<h2>{post.title}</h2>
+			<div>{post.body}</div>
+		</article>
+	));
+};
 ```
 
 Lorsque React affiche ce composant, Redwood va:
@@ -64,23 +62,24 @@ L'exécution de cette commande provoque la création d'un nouveau fichier `/web/
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
 export const QUERY = gql`
-  query BlogPostsQuery {
-    blogPosts {
-      id
-    }
-  }
-`
+	query BlogPostsQuery {
+		blogPosts {
+			id
+		}
+	}
+`;
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <div>Loading...</div>;
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <div>Empty</div>;
 
-export const Failure = ({ error }) => <div>Error: {error.message}</div>
+export const Failure = ({ error }) => <div>Error: {error.message}</div>;
 
 export const Success = ({ blogPosts }) => {
-  return JSON.stringify(blogPosts)
-}
+	return JSON.stringify(blogPosts);
+};
 ```
+
 > Lorsque vous utilisez le générateur, vous pouvez employer le type de casse qui vous plaît. Redwood fera en sorte de s'adapter pour créer une cellule avec un nom de fichier correct. Ainsi toutes les commandes ci-dessous aboutissent à créer un fichier avec le même nom:
 >
 >     yarn rw g cell blog_posts
@@ -88,49 +87,49 @@ export const Success = ({ blogPosts }) => {
 >     yarn rw g cell blogPosts
 >     yarn rw g cell BlogPosts
 >
-> Vous devez juste pensez à indiquer d'une façon ou d'une autre que vous utilisez plusieurs mots. Appeler `yarn redwood g cell blogposts` sans utiliser aucune casse pour séparer "blog" et "posts" va générer un fichier `web/src/components/BlogpostsCell/BlogpostsCell.js`.  
+> Vous devez juste pensez à indiquer d'une façon ou d'une autre que vous utilisez plusieurs mots. Appeler `yarn redwood g cell blogposts` sans utiliser aucune casse pour séparer "blog" et "posts" va générer un fichier `web/src/components/BlogpostsCell/BlogpostsCell.js`.
 
-Pour vous aider à être efficace, le générateur suppose que vous utiliserez une requête racine GraphQL nommées de la même façon que votre Cell et écrit pour vous une requête minimale pour récupérer des données depuis la base. Dans le cas présent, la requête a donc été nommée `blogPosts`. Cependant, ce nom de requête n'est pas valide par rapport à ce qui a déjà été créé dans nos fichiers SDL et Service. Nous devons donc renommer `blogPosts` en `posts` à la fois dans le nom de la requête GraphQL et dans la propriété passée à `Success`: 
+Pour vous aider à être efficace, le générateur suppose que vous utiliserez une requête racine GraphQL nommées de la même façon que votre Cell et écrit pour vous une requête minimale pour récupérer des données depuis la base. Dans le cas présent, la requête a donc été nommée `blogPosts`. Cependant, ce nom de requête n'est pas valide par rapport à ce qui a déjà été créé dans nos fichiers SDL et Service. Nous devons donc renommer `blogPosts` en `posts` à la fois dans le nom de la requête GraphQL et dans la propriété passée à `Success`:
 
-```javascript{5,17,18}
+```javascript {5,17,18}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
 export const QUERY = gql`
-  query BlogPostsQuery {
-    posts {
-      id
-    }
-  }
-`
+	query BlogPostsQuery {
+		posts {
+			id
+		}
+	}
+`;
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <div>Loading...</div>;
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <div>Empty</div>;
 
-export const Failure = ({ error }) => <div>Error: {error.message}</div>
+export const Failure = ({ error }) => <div>Error: {error.message}</div>;
 
 export const Success = ({ posts }) => {
-  return JSON.stringify(posts)
-}
+	return JSON.stringify(posts);
+};
 ```
 
 Insérons cette Cell dans notre `HomePage` et voyons ce qui se passe:
 
-```javascript{4,9}
+```javascript {4,9}
 // web/src/pages/HomePage/HomePage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
-import BlogPostsCell from 'src/components/BlogPostsCell'
+import BlogLayout from "src/layouts/BlogLayout";
+import BlogPostsCell from "src/components/BlogPostsCell";
 
 const HomePage = () => {
-  return (
-    <BlogLayout>
-      <BlogPostsCell />
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<BlogPostsCell />
+		</BlogLayout>
+	);
+};
 
-export default HomePage
+export default HomePage;
 ```
 
 Le navigateur devrait en principe montrer un tableau avec un peu de contenu (en supposant que vous ayez créé un article à l'étape du [scaffolding](/tutorial/getting-dynamic#creating-a-post-editor) un peu plus tôt). Impeccable!
@@ -139,35 +138,35 @@ Le navigateur devrait en principe montrer un tableau avec un peu de contenu (en 
 
 > **Dans le composant `Success`, d'où vient donc `posts`?**
 >
-> Remarquez que dans le composant `QUERY`, nous avons nommée notre requête `posts`. Quelque soit le nom de la requête, ce sera le nom de la propriété qui sera transmise au composant `Success` et qui  contiendra vos données. Vous pouvez toutefois créer un alias de la façon suivante:  
+> Remarquez que dans le composant `QUERY`, nous avons nommée notre requête `posts`. Quelque soit le nom de la requête, ce sera le nom de la propriété qui sera transmise au composant `Success` et qui contiendra vos données. Vous pouvez toutefois créer un alias de la façon suivante:
 >
 > ```javascript
 > export const QUERY = gql`
->   query BlogPostsQuery {
->     postIds: posts {
->       id
->     }
->   }
-> `
+> 	query BlogPostsQuery {
+> 		postIds: posts {
+> 			id
+> 		}
+> 	}
+> `;
 > ```
 >
 > De cette manière la propriété `postIds` sera transmise à `Success` au lieu de `posts`
 
 En plus de l'identifiant `id` qui a été ajouté dans `QUERY` par le générateur, récupérons également le titre, le contenu et la date de création de l'article:
 
-```javascript{7-9}
+```javascript {7-9}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
 export const QUERY = gql`
-  query BlogPostsQuery {
-    posts {
-      id
-      title
-      body
-      createdAt
-    }
-  }
-`
+	query BlogPostsQuery {
+		posts {
+			id
+			title
+			body
+			createdAt
+		}
+	}
+`;
 ```
 
 La page devrait désormais afficher un dump de l'ensemble des données pour tous les articles enregistrés:
@@ -176,20 +175,20 @@ La page devrait désormais afficher un dump de l'ensemble des données pour tous
 
 `Success` est ni plus ni moins qu'un bon vieux composant React, vous pouvez donc le modifier simplement pour afficher chaque article dans un format un peu plus sympa et lisible:
 
-```javascript{4-12}
+```javascript {4-12}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
 export const Success = ({ posts }) => {
-  return posts.map((post) => (
-    <article key={post.id}>
-      <header>
-        <h2>{post.title}</h2>
-      </header>
-      <p>{post.body}</p>
-      <div>Créé le: {post.createdAt}</div>
-    </article>
-  ))
-}
+	return posts.map((post) => (
+		<article key={post.id}>
+			<header>
+				<h2>{post.title}</h2>
+			</header>
+			<p>{post.body}</p>
+			<div>Créé le: {post.createdAt}</div>
+		</article>
+	));
+};
 ```
 
 Et ce faisant, nous avons maintenant notre blog! Ok, à ce stade c'est encore le plus basique et hideux blog jamais vu sur Internet.. mais c'est déjà quelque chose! (Pas d'inquiétude, nous avons encore un tas de fonctionnalités à ajouter)
@@ -205,7 +204,7 @@ Pour résumer, qu'avons nous réalisé jusqu'ici ?
 3. Définition du schéma de la base de données
 4. Application d'une migrations pour mettre à jour la base de données et créer une table
 5. Réalisation d'un Scaffold pour créer une interface CRUD sur la table
-6. Création d'une Cell pour charger les donner et gérer les états "loading", "empty", "failure" et enfin "success". 
+6. Création d'une Cell pour charger les donner et gérer les états "loading", "empty", "failure" et enfin "success".
 7. Ajout de la Cell à notre page d'accueil
 
 En réalité, cette différentes étapes sont ni plus ni moins ce qui deviendra votre façon habituelle d'ajouter de nouvelles fonctionnalités dans une application Redwood.

--- a/to-upload/fr/deployment.md
+++ b/to-upload/fr/deployment.md
@@ -24,7 +24,7 @@ Avant que nous ne poursuivions, assurez-vous que tous les commits soient faits e
 
 > **NOTE:** Git utilise par défaut une branche `master`. Vous ne savez pas comment renommer `master` en `main`? Si vous utilisez GitHub, vous pouvez suivre ces étapes:
 >
-> ```plaintext{4,6}
+> ```plaintext {4,6}
 > git init
 > git add .
 > git commit -m 'First commit'
@@ -35,7 +35,7 @@ Avant que nous ne poursuivions, assurez-vous que tous les commits soient faits e
 
 ### Vercel (cible de déploiement alternative)
 
-Redwood supporte officiellement plusieurs fournisseurs d'hébergement (et d'autres sont en cours d'ajout). Bien que ce didacticiel se poursuive en s'appuyant sur Netlify pour le déploiement et l'authentification, il vous est possible de déployer sur [Vercel](https://vercel.com/redwoodjs-core). Pour cela, commencer par achever la section suivante ("La Base de Données"), mais utilisez ce [guide de déploiement Vercel](https://redwoodjs.com/docs/deploy#redwood-deploy-configuration) à la place des instructions dédiées à Netlify. **Note**: Netlify Identity, used in the upcoming "Authentication" section, won't work on the Vercel platform.  
+Redwood supporte officiellement plusieurs fournisseurs d'hébergement (et d'autres sont en cours d'ajout). Bien que ce didacticiel se poursuive en s'appuyant sur Netlify pour le déploiement et l'authentification, il vous est possible de déployer sur [Vercel](https://vercel.com/redwoodjs-core). Pour cela, commencer par achever la section suivante ("La Base de Données"), mais utilisez ce [guide de déploiement Vercel](https://redwoodjs.com/docs/deploy#redwood-deploy-configuration) à la place des instructions dédiées à Netlify. **Note**: Netlify Identity, used in the upcoming "Authentication" section, won't work on the Vercel platform.
 
 ### La Base de Données
 
@@ -44,10 +44,10 @@ Nous avons besoin d'une base de données quelque part sur Internet afin d'enregi
 Tout d'abord, nous allons informer Prisma que nous souhaitons utiliser Postgres en plkus de SQLite, de telle manière que Prisma va construire un client pour ces deux bases de données. Mettez à jour l'entrée `provider` dans `schema.prisma`:
 
 ```javascript
-provider = ["sqlite", "postgresql"]
+provider = ["sqlite", "postgresql"];
 ```
 
-Si vous souhaitez développer en local avec Postgres, [consultez le guide](https://redwoodjs.com/docs/local-postgres-setup). 
+Si vous souhaitez développer en local avec Postgres, [consultez le guide](https://redwoodjs.com/docs/local-postgres-setup).
 
 > Pour l'instant, vous avez besoin de créer votre propre base de données, mais nous travaillons avec différents fournisseurs d'infrastructure pour mettre un place un processus plus simple et plus en phase avec la Jamstack. Plus d'informations sont à venir sur ce point!
 
@@ -63,7 +63,7 @@ Rendez-vous sur le site d'[Heroku](https://signup.heroku.com/), créez un nouvea
 
 <img alt="Screen Shot 2020-02-03 at 3 22 36 PM" src="https://user-images.githubusercontent.com/300/73703866-438c3900-46a6-11ea-9a90-bdab2fed8bff.png" />
 
-Donnez lui un nom comme "redwoodblog". Puis allez sur l'onglet **Ressources** et cliquez sur le bouton **Find more add-ons** dans la section **Add-ons**: 
+Donnez lui un nom comme "redwoodblog". Puis allez sur l'onglet **Ressources** et cliquez sur le bouton **Find more add-ons** dans la section **Add-ons**:
 
 <img alt="Screen Shot 2020-02-03 at 3 23 25 PM" src="https://user-images.githubusercontent.com/300/73703877-4e46ce00-46a6-11ea-87c0-079346f4d9b3.png" />
 
@@ -87,7 +87,7 @@ Cette ligne est particulièrement longue, assurez-vous que vous avez bien sélec
 
 ### Netlify
 
-Maintenant, si vous n'en avez pas déjà un, créez un [compte Netlify](https://app.netlify.com/signup). Ceci étant fait, cliquez simplement sur le boutton **New site from Git** situé en haut à droite: 
+Maintenant, si vous n'en avez pas déjà un, créez un [compte Netlify](https://app.netlify.com/signup). Ceci étant fait, cliquez simplement sur le boutton **New site from Git** situé en haut à droite:
 
 <img src="https://user-images.githubusercontent.com/300/73697486-85f84a80-4693-11ea-922f-0f134a3e9031.png" />
 
@@ -95,13 +95,13 @@ Donnez l'autorisation à Netlify de se connecter à votre fournisseur d'héberge
 
 Netlify va alors construire votre application (cliquez sur **Deploying your site** pour prendre connaissance des logs) puis va dire "Site is live",... et rien ne va fonctionner :D Pourquoi? Et pardi, car nous n'avons pas précisé où se trouve notre base de données!
 
-Retournez sur la page principale de Netlify, puis rendez-vous dans **Settings**, puis dans **Build & Deploy** > **Environment**. Cliquez sur **Edit variables**. C'est à cet endroit que nous allons coller l'URI de connection que nous avions copié depuis Heroku (notez que la valeur de **Key** est "DATABASE_URL"). Après avoir collé la valeur, ajoutez `?connection_limit=1` à la fin d'URI. Le format final de l'URI est donc:  `postgres://<user>:<pass>@<url>/<db>?connection_limit=1`.
+Retournez sur la page principale de Netlify, puis rendez-vous dans **Settings**, puis dans **Build & Deploy** > **Environment**. Cliquez sur **Edit variables**. C'est à cet endroit que nous allons coller l'URI de connection que nous avions copié depuis Heroku (notez que la valeur de **Key** est "DATABASE_URL"). Après avoir collé la valeur, ajoutez `?connection_limit=1` à la fin d'URI. Le format final de l'URI est donc: `postgres://<user>:<pass>@<url>/<db>?connection_limit=1`.
 
 ![Adding ENV var](https://user-images.githubusercontent.com/300/83188236-3e834780-a0e4-11ea-8cfa-790c2e335a92.png)
 
 > Lorsque vous configurez la base de données, vous ajouterez de préférence `?connection_limit=1` à l'URI. Il s'agit d'une [recommandation pour l'utilisation de Prisma](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/deployment#recommended-connection-limit) dans le cadre d'une utilisation Serverless.
 
-Assurez-vous de cliquer sur le boutton **Save**. Maintenant rendez-vous sur l'onglet **Deploys**, ouvrez le champ de sélection **Trigger deploy** sur la droite et choisissez **Deploy site**: 
+Assurez-vous de cliquer sur le boutton **Save**. Maintenant rendez-vous sur l'onglet **Deploys**, ouvrez le champ de sélection **Trigger deploy** sur la droite et choisissez **Deploy site**:
 
 ![Trigger deploy](https://user-images.githubusercontent.com/300/83187760-835aae80-a0e3-11ea-9733-ff54969bba1f.png)
 
@@ -113,7 +113,7 @@ Est-ce que ça fonctionne? Si vous voyez "Empty" sous les liens _About_ et _Cont
 
 > Si vous regardez le déploiement via le bouton **Preview**, remarquez que l'URL contient un hash du dernier commit. Netlify va en créer un à chaque nouveau push sur la branche `main` mais ne montrera que ce commit. Donc si vous déployez à nouveau en executant un refresh, vous ne verrez aucune modification. L'URL de déploiement de votre site (celle que vous obtenez depuis la page d'accueil de Netlify) affichera toujours le dernier déploiement. Consultez la section suivante "[Déploiement de Branche](#branch-deploys)" pour plus d'informations.
 
-Si votre déploiement n'a pas fonctionné, consultez le log dans Netlify et voyez si vous comprenez l'erreur qui s'affiche. Si votre déploiement s'esst correctement effectué mais que le site ne s'affiche pas, essayez d'ouvrir les outils de développement de votre navigateur afin de voir si des erreurs s'affichent. Assurez-vous également de bien avoir copié _en totalité_ l'URI de connection Postgres depuis Heroku. Si véritablement vous ne parvenez pas à trouver d'où vient l'erreur, demandez-donc de l'aide à la [communauté Redwood](https://community.redwoodjs.com).  
+Si votre déploiement n'a pas fonctionné, consultez le log dans Netlify et voyez si vous comprenez l'erreur qui s'affiche. Si votre déploiement s'esst correctement effectué mais que le site ne s'affiche pas, essayez d'ouvrir les outils de développement de votre navigateur afin de voir si des erreurs s'affichent. Assurez-vous également de bien avoir copié _en totalité_ l'URI de connection Postgres depuis Heroku. Si véritablement vous ne parvenez pas à trouver d'où vient l'erreur, demandez-donc de l'aide à la [communauté Redwood](https://community.redwoodjs.com).
 
 ### Déploiements de Branche
 
@@ -125,4 +125,4 @@ Une autre fonctionnalité bien pratique de Netlify est appelée _branch deploys_
 
 ### Une remarque à propos des connections aux bases de données
 
-Dans ce didacticiel, vos fonctions lambda vont se connecter directement à la base Postgres. Dans la mesure où Postgres à un nombre limité de connections concurrentes possibles, son utilisation peut devenir problématique lorsque le nombre d'utlisateurs croît énormément. La bonne solution est de mettre en place un service de "connection pooling" devant Postgres et y connecter vos fonctions lambda. Pour apprendre comment faire ça, consulter le [guide associé](https://www.redwoodjs.com/docs/connection-pooling). 
+Dans ce didacticiel, vos fonctions lambda vont se connecter directement à la base Postgres. Dans la mesure où Postgres à un nombre limité de connections concurrentes possibles, son utilisation peut devenir problématique lorsque le nombre d'utlisateurs croît énormément. La bonne solution est de mettre en place un service de "connection pooling" devant Postgres et y connecter vos fonctions lambda. Pour apprendre comment faire ça, consulter le [guide associé](https://www.redwoodjs.com/docs/connection-pooling).

--- a/to-upload/fr/everyones-favorite-thing-to-build-forms.md
+++ b/to-upload/fr/everyones-favorite-thing-to-build-forms.md
@@ -4,7 +4,7 @@ title: "Votre partie préférée: Les Formulaires"
 sidebar_label: "Votre partie préférée: Les Formulaires"
 ---
 
-Attendez! Ne partez pas! Vous deviez bien vous douter que ça allait venir, non? Rassurez-vous, pour les formulaires aussi, Redwood a trouvé une façon de faire qui les rend moins pénible que d'habitude. En fait, Redwood pourrait même vous faire _aimer_ les formulaires. Bon, aimer est peut-être un peu fort. Disons _apprécier_ travailler avec les formulaires, ou à tout le moins les _tolérer_?   
+Attendez! Ne partez pas! Vous deviez bien vous douter que ça allait venir, non? Rassurez-vous, pour les formulaires aussi, Redwood a trouvé une façon de faire qui les rend moins pénible que d'habitude. En fait, Redwood pourrait même vous faire _aimer_ les formulaires. Bon, aimer est peut-être un peu fort. Disons _apprécier_ travailler avec les formulaires, ou à tout le moins les _tolérer_?
 
 La troisième partie du didacticiel en video commence ici:
 
@@ -14,7 +14,7 @@ La troisième partie du didacticiel en video commence ici:
 
 Nous avons déjà un formulaire ou deux dans notre application; vous rappellez-vous notre _scaffolding_ avec les articles? Ils fonctionnaient plus bien, non? Alors, a quel point est-ce difficile de reproduire ces formulaires? (Si vous n'avez pas encore eu la curiosité d'aller voir le code généré, ce qui va suivre va vous surprendre)
 
-Construisons donc le formulaire le plus élémentaire qui soit pour notre blog, et utile de surcroît, celui qui permettra à vos lecteurs de vous contacter. 
+Construisons donc le formulaire le plus élémentaire qui soit pour notre blog, et utile de surcroît, celui qui permettra à vos lecteurs de vous contacter.
 
 ### La Page
 
@@ -22,56 +22,56 @@ Construisons donc le formulaire le plus élémentaire qui soit pour notre blog, 
 
 Après avoir exécuté cette commande, nous pouvons ajouter un lien vers Contact dans notre Layout:
 
-```javascript{17-19}
+```javascript {17-19}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const BlogLayout = ({ children }) => {
-  return (
-    <>
-      <header>
-        <h1>
-          <Link to={routes.home()}>Redwood Blog</Link>
-        </h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-            <li>
-              <Link to={routes.contact()}>Contact</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>{children}</main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>
+					<Link to={routes.home()}>Redwood Blog</Link>
+				</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+						<li>
+							<Link to={routes.contact()}>Contact</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>{children}</main>
+		</>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 And then use the `BlogLayout` in the `ContactPage`:
 
-```javascript{3,6}
+```javascript {3,6}
 // web/src/pages/ContactPage/ContactPage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  return <BlogLayout></BlogLayout>
-}
+	return <BlogLayout></BlogLayout>;
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 Vérifiez que tout fonctionne correctement, puis passons aux réjouïssances.
 
 ### Présentation des Form Helpers
 
-Les formulaires avec React sont surtout connus pour être particulièrement agaçants à construire. Il existes les [Controlled Components](https://reactjs.org/docs/forms.html#controlled-components), les [Uncontrolled Components](https://reactjs.org/docs/uncontrolled-components.html), diverses [librairies tierces](https://jaredpalmer.com/formik/) et enfin pas mal d'astuces diverses pour essayer de les rendre aussi simples qu'ils sont sensés être selon les spécifications HTML: un champ `<input>` avec un attribut `name` qui sera envoyé quelque part lorsque l'utilisateur clique sur un bouton.  
+Les formulaires avec React sont surtout connus pour être particulièrement agaçants à construire. Il existes les [Controlled Components](https://reactjs.org/docs/forms.html#controlled-components), les [Uncontrolled Components](https://reactjs.org/docs/uncontrolled-components.html), diverses [librairies tierces](https://jaredpalmer.com/formik/) et enfin pas mal d'astuces diverses pour essayer de les rendre aussi simples qu'ils sont sensés être selon les spécifications HTML: un champ `<input>` avec un attribut `name` qui sera envoyé quelque part lorsque l'utilisateur clique sur un bouton.
 
 Nous pensons que Redwood fait quelques pas dans la bonne direction, non seulement en vous libérant d'avoir à écrire un tans de code relatif aux composants controllés (controlled components), mais aussi en s'occupant de gérer automatiquement les validations et éventuelles erreurs. Regardons ensemble comment tout celà fonctionne.
 
@@ -80,86 +80,90 @@ Avant de commencer, ajoutons quelques classes CSS pour que les formulaires par d
 ```css
 /* web/src/index.css */
 
-button, input, label, textarea {
-  display: block;
-  outline: none;
+button,
+input,
+label,
+textarea {
+	display: block;
+	outline: none;
 }
 
 label {
-  margin-top: 1rem;
+	margin-top: 1rem;
 }
 
 .error {
-  color: red;
+	color: red;
 }
 
-input.error, textarea.error {
-  border: 1px solid red;
+input.error,
+textarea.error {
+	border: 1px solid red;
 }
 ```
 
 Pour l'instant nous n'allons pas faire dialoguer notre formulaire de contact avec la base de données, raison pour laquelle nous ne générons pas une Cell. Nous allons simplement ajouter le formulaire à notre page. Dans Redwood, la création d'un formulaire débute par... attention à la surprise...une balise `<Form>`:
 
-```javascript{3,9}
+```javascript {3,9}
 // web/src/pages/ContactPage/ContactPage.js
 
-import { Form } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  return (
-    <BlogLayout>
-      <Form></Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form></Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 Humm, OK... pour le moment rien d'incroyable. Ajoutons un premier champ que l'on puisse au moins afficher quelque chose. Redwood propose une variété de type de champs parmi lesquels se trouve `<TextField>`. Ce dernier correspond à un champ text tout ce qu'il y a de plus basique. Il possède un attribut `name` de telle façon que lorsqu'un formulaire contient de multiples champs, il soit possible de savoir lequel contient telle ou telle donnée.
 
-```javascript{3,10}
+```javascript {3,10}
 // web/src/pages/ContactPage/ContactPage.js
 
-import { Form, TextField } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  return (
-    <BlogLayout>
-      <Form>
-        <TextField name="input" />
-      </Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form>
+				<TextField name="input" />
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258121-4f4d2300-8637-11ea-83f5-c667e05aaf74.png" />
 
 Enfin quelque chose s'affiche! Pas encore très intéressant toutefois. Ajoutons un bouton "envoyer".
 
-```javascript{3,11}
+```javascript {3,11}
 // web/src/pages/ContactPage/ContactPage.js
 
-import { Form, TextField, Submit } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, Submit } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  return (
-    <BlogLayout>
-      <Form>
-        <TextField name="input" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form>
+				<TextField name="input" />
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258188-7572c300-8637-11ea-9583-1b7636f93be0.png" />
@@ -170,23 +174,23 @@ Nous obtenons ce qu'on peut considérer comme un véritable et authentique formu
 
 De façon similaire à un formulaire HTML, une balise `<Form>` possède un "_handler_" `onSubmit`. Ce handler sera appelé avec un seul argument: un unique objet contenant l'ensemble des champs du formulaire.
 
-```javascript{4-6,10}
+```javascript {4-6,10}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
-  const onSubmit = (data) => {
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <TextField name="input" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form onSubmit={onSubmit}>
+				<TextField name="input" />
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 ```
 
 Essayons maintenant de saisir quelques mots puis soumettre ce formulaire:
@@ -195,30 +199,30 @@ Essayons maintenant de saisir quelques mots puis soumettre ce formulaire:
 
 Extra! Rendons le formulaire un peu plus utile en ajoutant quelques champs supplémentaires. Nous renommons ainsi notre premier champ en `name` puis ajoutons les champs `email` et `message`:
 
-```javascript{3,15,16}
+```javascript {3,15,16}
 // web/src/pages/ContactPage/ContactPage.js
 
-import { Form, TextField, TextAreaField, Submit } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, TextAreaField, Submit } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  const onSubmit = (data) => {
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <TextField name="name" />
-        <TextField name="email" />
-        <TextAreaField name="message" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<Form onSubmit={onSubmit}>
+				<TextField name="name" />
+				<TextField name="email" />
+				<TextAreaField name="message" />
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 Remarquez le nouveau composant `<TextAreaField>` qui génère une balise HTML `<textarea>` contenant quelques spécificités utiles propres à Redwood:
@@ -227,25 +231,25 @@ Remarquez le nouveau composant `<TextAreaField>` qui génère une balise HTML `<
 
 Ajoutons également quelques étiquettes en face des champs:
 
-```javascript{6,9,12}
+```javascript {6,9,12}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258431-15c8e780-8638-11ea-8eca-0bd222b51d8a.png" />
@@ -254,29 +258,29 @@ Essayez donc de soumettre à nouveau le formulaire, vous devriez obtenir dans la
 
 ### Validation
 
-"Humm... cher auteur de ce didacticiel, qui a-t-il d'incroyable jusqu'ici?". C'est sans doute votre état d'esprit à ce stade. En effet, il existe déjà un nombre conséquent de librairies permettant d'obtenir un résultat similaire.. Vous avez raison! N'importe qui peut remblir un formulaire _correctement_, mais que se passe-t-il lorsqu'un utilisateur fait une erreur, oubli un champ, voire tente de jouer les hackers? Qui va vous aider à gérer cette situation? Redwood va le faire. 
+"Humm... cher auteur de ce didacticiel, qui a-t-il d'incroyable jusqu'ici?". C'est sans doute votre état d'esprit à ce stade. En effet, il existe déjà un nombre conséquent de librairies permettant d'obtenir un résultat similaire.. Vous avez raison! N'importe qui peut remblir un formulaire _correctement_, mais que se passe-t-il lorsqu'un utilisateur fait une erreur, oubli un champ, voire tente de jouer les hackers? Qui va vous aider à gérer cette situation? Redwood va le faire.
 
 Tout d'abord, ce trois champs devraient être obligatoirement remplis pour pouvoir soumettre le formulaire. Rendons cette règle obligatoire en utilisant l'attribut HTML standard `required`:
 
-```javascript{7,10,13}
+```javascript {7,10,13}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" required />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" required />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" required />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" required />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" required />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" required />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258542-5163b180-8638-11ea-8450-8a727de177ad.png" />
@@ -285,73 +289,66 @@ Désormais, lorsque vous essayez de soumettre le formulaire, un message s'affich
 
 Oui! Remplaçons cet attribut `required` par un object que nous passons à un attribut nommé `validation`, spécifique à Redwood:
 
-```javascript{7,10,13}
+```javascript {7,10,13}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" validation={{ required: true }} />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" validation={{ required: true }} />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" validation={{ required: true }} />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" validation={{ required: true }} />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" validation={{ required: true }} />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" validation={{ required: true }} />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
-Maintenant lorsqu'un champ reste vide, le formulaire n'est pas envoyé et le champ en question prend le focus de telle manière que l'utilisateur puisse saisir une valeur. Pas encore stupéfiant, mais c'est une première étape. Redwood a d'autres fonctions sympatiques pour les formulaires, dont la possibilité d'afficher les erreurs à côté des champs.  
-
+Maintenant lorsqu'un champ reste vide, le formulaire n'est pas envoyé et le champ en question prend le focus de telle manière que l'utilisateur puisse saisir une valeur. Pas encore stupéfiant, mais c'est une première étape. Redwood a d'autres fonctions sympatiques pour les formulaires, dont la possibilité d'afficher les erreurs à côté des champs.
 
 ### `<FieldError>`
 
 Pour celà, voici le composant `<FieldError>` (n'oubliez pas d'inclure l'`import` associé en haut du fichier):
 
-```javascript{8,22,26,30}
+```javascript {8,22,26,30}
 // web/src/pages/ContactPage/ContactPage.js
 
-import {
-  Form,
-  TextField,
-  TextAreaField,
-  Submit,
-  FieldError,
-} from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, TextAreaField, Submit, FieldError } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  const onSubmit = (data) => {
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <label htmlFor="name">Name</label>
-        <TextField name="name" validation={{ required: true }} />
-        <FieldError name="name" />
+	return (
+		<BlogLayout>
+			<Form onSubmit={onSubmit}>
+				<label htmlFor="name">Name</label>
+				<TextField name="name" validation={{ required: true }} />
+				<FieldError name="name" />
 
-        <label htmlFor="email">Email</label>
-        <TextField name="email" validation={{ required: true }} />
-        <FieldError name="email" />
+				<label htmlFor="email">Email</label>
+				<TextField name="email" validation={{ required: true }} />
+				<FieldError name="email" />
 
-        <label htmlFor="message">Message</label>
-        <TextAreaField name="message" validation={{ required: true }} />
-        <FieldError name="message" />
+				<label htmlFor="message">Message</label>
+				<TextAreaField name="message" validation={{ required: true }} />
+				<FieldError name="message" />
 
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 Observez que l'attribut `name` correspond à celui du champ au dessus. De cette manière, Redwood sait où afficher le message d'erreur d'un champ.
@@ -360,132 +357,101 @@ Observez que l'attribut `name` correspond à celui du champ au dessus. De cette 
 
 Mais c'est juste le début. Maintenant faisons en sorte que nos utilisateurs sachent qu'il s'agisse bien d'un message d'erreur. Vous rappellez-vous la classe CSS `.error` que nous avions définie dans `index.css`? Indiquons-la à l'attribut `className` de nos composants `<FieldError>`:
 
-```javascript{8,12,16}
+```javascript {8,12,16}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" validation={{ required: true }} />
-      <FieldError name="name" className="error" />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" validation={{ required: true }} />
+			<FieldError name="name" className="error" />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" validation={{ required: true }} />
-      <FieldError name="email" className="error" />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" validation={{ required: true }} />
+			<FieldError name="email" className="error" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" validation={{ required: true }} />
-      <FieldError name="message" className="error" />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" validation={{ required: true }} />
+			<FieldError name="message" className="error" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 <img src="https://user-images.githubusercontent.com/300/73306040-3cf65100-41d0-11ea-99a9-9468bba82da7.png" />
 
 Vous savez ce qui serez bien? Que le champ lui-même indique qu'il y a eu une erreur. Remarquez ici l'utilisation de l'attribut `errorClassName`:
 
-```javascript{10,18,26}
+```javascript {10,18,26}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField
-        name="name"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="name" className="error" />
+	<BlogLayout>
+		<Form onSubmit={onSubmit}>
+			<label htmlFor="name">Name</label>
+			<TextField name="name" validation={{ required: true }} errorClassName="error" />
+			<FieldError name="name" className="error" />
 
-      <label htmlFor="email">Email</label>
-      <TextField
-        name="email"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="email" className="error" />
+			<label htmlFor="email">Email</label>
+			<TextField name="email" validation={{ required: true }} errorClassName="error" />
+			<FieldError name="email" className="error" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField
-        name="message"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="message" className="error" />
+			<label htmlFor="message">Message</label>
+			<TextAreaField name="message" validation={{ required: true }} errorClassName="error" />
+			<FieldError name="message" className="error" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
-)
+			<Submit>Save</Submit>
+		</Form>
+	</BlogLayout>
+);
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80258907-39d8f880-8639-11ea-8816-03a11c69e8ac.png" />
 
 Bravo! Et maintenant, appliquons ce principe à l'étiquette elle-même. Pour celà utilisons le composant `<Label>` fourni par Redwood. Notez comme l'attribut `for` correspond à la valeur de l'attribut `name` du composant associé. N'oubliez pas également d'importer le composant:
 
-```javascript{9,21-23,31-33,41-43}
+```javascript {9,21-23,31-33,41-43}
 // web/src/pages/ContactPage/ContactPage.js
 
-import {
-  Form,
-  TextField,
-  TextAreaField,
-  Submit,
-  FieldError,
-  Label,
-} from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, TextAreaField, Submit, FieldError, Label } from "@redwoodjs/forms";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const ContactPage = () => {
-  const onSubmit = (data) => {
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <Label name="name" errorClassName="error">
-          Name
-        </Label>
-        <TextField
-          name="name"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="name" className="error" />
+	return (
+		<BlogLayout>
+			<Form onSubmit={onSubmit}>
+				<Label name="name" errorClassName="error">
+					Name
+				</Label>
+				<TextField name="name" validation={{ required: true }} errorClassName="error" />
+				<FieldError name="name" className="error" />
 
-        <Label name="email" errorClassName="error">
-          Email
-        </Label>
-        <TextField
-          name="email"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="email" className="error" />
+				<Label name="email" errorClassName="error">
+					Email
+				</Label>
+				<TextField name="email" validation={{ required: true }} errorClassName="error" />
+				<FieldError name="email" className="error" />
 
-        <Label name="message" errorClassName="error">
-          Message
-        </Label>
-        <TextAreaField
-          name="message"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="message" className="error" />
+				<Label name="message" errorClassName="error">
+					Message
+				</Label>
+				<TextAreaField name="message" validation={{ required: true }} errorClassName="error" />
+				<FieldError name="message" className="error" />
 
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+				<Submit>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80259003-70af0e80-8639-11ea-97cf-b6b816118fbf.png" />
@@ -496,37 +462,16 @@ export default ContactPage
 
 Nous devrions nous assurer que le champ email contient bien... un email!
 
-```html{7-9}
-// web/src/pages/ContactPage/ContactPage.js
-
-<TextField
-  name="email"
-  validation={{
-    required: true,
-    pattern: {
-      value: /[^@]+@[^.]+\..+/,
-    },
-  }}
-  errorClassName="error"
-/>
+```html {7-9}
+// web/src/pages/ContactPage/ContactPage.js <TextField name="email" validation={{ required: true, pattern: { value:
+/[^@]+@[^.]+\..+/, }, }} errorClassName="error" />
 ```
 
 OK, ça n'est pas la validation ultime pour un champ email, mais pour le moment faisons comme si. Modifions également le message affiché en cas d'échec de la validation:
 
-```html{9}
-// web/src/pages/ContactPage/ContactPage.js
-
-<TextField
-  name="email"
-  validation={{
-    required: true,
-    pattern: {
-      value: /[^@]+@[^.]+\..+/,
-      message: 'Please enter a valid email address',
-    },
-  }}
-  errorClassName="error"
-/>
+```html {9}
+// web/src/pages/ContactPage/ContactPage.js <TextField name="email" validation={{ required: true, pattern: { value:
+/[^@]+@[^.]+\..+/, message: 'Please enter a valid email address', }, }} errorClassName="error" />
 ```
 
 <img src="https://user-images.githubusercontent.com/300/80259139-bd92e500-8639-11ea-99d5-be278dc67afc.png" />
@@ -538,16 +483,13 @@ Vous avez peut-être remarqué qu'essayer d'envoyer le formulaire alors que sont
 Finalement, savez-vous ce qui serait _vraiment_ sympa? Ce serait de faire en sorte que les champs soient validés dès que l'utilisateur quitte un champ. De cette manière l'utilisateur n'a pas besoin de remplir l'ensemble des champs et envoyer le formulaire pour voir toutes les erreurs s'afficher. Voyons comment faire:
 
 ```html
-// web/src/pages/ContactPage/ContactPage.js
-
-<Form onSubmit={onSubmit} validation={{ mode: 'onBlur' }}>
+// web/src/pages/ContactPage/ContactPage.js <Form onSubmit={onSubmit} validation={{ mode: 'onBlur' }}>
 ```
 
 Alors, qu'en pensez-vous? Quelques composants, un ou deux attributs, et vous avez devant vous un formulaire qui gère les erreurs, valide les champs et vous envoie le contenu sous la forme d'un bel objet javascript. Merci Redwood!
 
-> Les formulaires de Redwood sont construits à partir de la librairie [React Hook Form](https://react-hook-form.com/). Celle-ci contient d'autres fonctionalités très utiles que nous n'avons pas documenté ici.  
+> Les formulaires de Redwood sont construits à partir de la librairie [React Hook Form](https://react-hook-form.com/). Celle-ci contient d'autres fonctionalités très utiles que nous n'avons pas documenté ici.
 
 Redwood a encore plus d'un tour dans son sac pour ce qui concerne les formulaires, mais nous allons garder ça pour une étape ultérieure.
 
 Avoir un formulaire de contact, c'est bien. Mais conserver les message qu'on vous envoie, c'est mieux! Procédons maintenant à la création de la table en base de données pour y enregistrer ces informations. Ce faisant nous allons créer notre première mutation GraphQL!
-

--- a/to-upload/fr/getting-dynamic.md
+++ b/to-upload/fr/getting-dynamic.md
@@ -12,7 +12,7 @@ La seconde partie du didacticiel est disponible en video ici:
 
 Ces deux pages sont plutôt sympas, mais un blog sans article c'est tout de même un peu léger! Travaillons sur ce point à présent.
 
-Pour les besoins de ce didacticiel, nous allons récupérer nos articles depuis la base de données. Puisque les bases de données relationelles sont encore aujourd'hui au coeur de beaucoup d'applications complexes (ou moins complexes d'ailleurs), nous avons fait en sorte de réserver un traitement de première classe aux accès SQL. Dans une application Redwood, tout part du schéma. 
+Pour les besoins de ce didacticiel, nous allons récupérer nos articles depuis la base de données. Puisque les bases de données relationelles sont encore aujourd'hui au coeur de beaucoup d'applications complexes (ou moins complexes d'ailleurs), nous avons fait en sorte de réserver un traitement de première classe aux accès SQL. Dans une application Redwood, tout part du schéma.
 
 ### Créer le schéma de la base de données
 
@@ -23,11 +23,11 @@ Nous devons identifier quelles données seront nécessaires pour un article. Plu
 - `body` le contenu de l'article
 - `createdAt` un 'timestamp' correspondant au moment où l'article est enregistré dans la base de données
 
-Nous utilisons [Prisma Client JS](https://github.com/prisma/prisma-client-js) pour parler vac la base de données. Prisma possède aun autre librairie, appellée [Migrate](https://github.com/prisma/migrate), qui nous permet de mettre à jour le schéma de la base de données en capturant chaque changement successif. Chacun de ces changement est appelé _migration_, et cette librairie Migrate en créé un nouveau à chaque modification du schéma.  
+Nous utilisons [Prisma Client JS](https://github.com/prisma/prisma-client-js) pour parler vac la base de données. Prisma possède aun autre librairie, appellée [Migrate](https://github.com/prisma/migrate), qui nous permet de mettre à jour le schéma de la base de données en capturant chaque changement successif. Chacun de ces changement est appelé _migration_, et cette librairie Migrate en créé un nouveau à chaque modification du schéma.
 
-Tout d'abord, définissons la structure d'un article de notre blog dans la base de données. Ouvrez `api/prisma/schema.prisma` et ajoutez la définition de la table `Post` (supprimez au passage tous les modèles présents par défaut dans ce fichier). Une fois terminé, le fichier se présente ainsi: 
+Tout d'abord, définissons la structure d'un article de notre blog dans la base de données. Ouvrez `api/prisma/schema.prisma` et ajoutez la définition de la table `Post` (supprimez au passage tous les modèles présents par défaut dans ce fichier). Une fois terminé, le fichier se présente ainsi:
 
-```plaintext{13-18}
+```plaintext {13-18}
 // api/prisma/schema.prisma
 
 datasource DS {
@@ -61,7 +61,7 @@ Cette série d'instructions signifie que nous voulons créer une table `Post` av
 >
 > `id String @id @default(cuid())`
 >
-> Notez que l'utilisation d'un identifiant de type Integer permet d'obtenir des url plus simples comme https://redwoodblog.com/posts/123 instead of https://redwoodblog.com/posts/eebb026c-b661-42fe-93bf-f1a373421a13. 
+> Notez que l'utilisation d'un identifiant de type Integer permet d'obtenir des url plus simples comme https://redwoodblog.com/posts/123 instead of https://redwoodblog.com/posts/eebb026c-b661-42fe-93bf-f1a373421a13.
 >
 > Allez voir la [documentation officielle de Prisma](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model#defining-an-id-field) pour plus de détails sur les champs identifiants.
 
@@ -119,11 +119,11 @@ D'accord, et en cliquant sur le bouton "Delete" (supprimer)?
 
 Oui c'est bien ça, en une seule commande, Redwood à créé l'ensemble des pages, composants et services nécessaires aux opérations usuelles de manipulation des articles. Pas même besoin d'ouvrir le gestionnaire de base de données. Redwood appelle ceci des _scaffolds_. Pas mal, non?
 
-Voici dans le détail ce qui arrive lorsqu'on execute la commande `yarn rw g scaffold post` : 
+Voici dans le détail ce qui arrive lorsqu'on execute la commande `yarn rw g scaffold post` :
 
-- Ajout d'un fichier _SDL_ pour définir quelques requêtes et mutations GraphQL dans `api/src/graphql/posts.sdl.js` 
+- Ajout d'un fichier _SDL_ pour définir quelques requêtes et mutations GraphQL dans `api/src/graphql/posts.sdl.js`
 - Ajout d'un fichier _service_ `api/src/services/posts/posts.js` qui permet au client Javascript Prisma de manipuler la base de données
-- Ajout de quelques _pages_ dans `web/src/pages`:  
+- Ajout de quelques _pages_ dans `web/src/pages`:
   - `EditPostPage` pour éditer un article
   - `NewPostPage` pour créer un nouvel article
   - `PostPage` pour montrer les détails d'un article
@@ -136,7 +136,7 @@ Voici dans le détail ce qui arrive lorsqu'on execute la commande `yarn rw g sca
 - Ajout de quatre _composants_ également dans `web/src/components`:
   - `NewPost` affiche le formulaire permettant la création d'un nouvel article
   - `Post` affiche un article en particulier
-  - `PostForm` le formulaire utilisé à la fois par les composants de création et d'édition d'un aricle 
+  - `PostForm` le formulaire utilisé à la fois par les composants de création et d'édition d'un aricle
   - `Posts` affiche la table avec l'ensemble des articles
 
 > **Générateurs et conventions de nommage**
@@ -152,7 +152,7 @@ Voici dans le détail ce qui arrive lorsqu'on execute la commande `yarn rw g sca
 > - Les Layouts utilisent le nom que vous leur donnez
 > - Les composants et les cellules sont au pluriel ou au singulier selon le contexte lorsqu'ils sont générés par scaffolding. Dans le cas contraire, ils utilisent simplement le nom que vous leur donnez.
 >
-> Remarquez également que seul le nom de la table en base de données et au singulier ou au pluriel, et pas le mot complet. Ainsi on a `PostsCell`, et non `PostCells`. 
+> Remarquez également que seul le nom de la table en base de données et au singulier ou au pluriel, et pas le mot complet. Ainsi on a `PostsCell`, et non `PostCells`.
 >
 > Vous n'avez pas à suivre cette convention de façon obligatoire lorsque vous créez vos propres composants, pages, etc... Ceci étant nous vous le recommandons chaudement. Au bout du compte, la communauté Ruby on Rails a fini par s'attacher à cette convention, et ce même si au départ de nombreuses personnes s'y étaient opposées. "[Give it five minutes](https://signalvnoise.com/posts/3124-give-it-five-minutes)" comme disent les anglo-saxons.
 
@@ -165,7 +165,6 @@ Nous pouvons commencer à remplacer ces pages les unes après les autres au fur 
 
 Puisque nous voudront probablement conserver un moyen de créer et éditer des articles plus tard, conservons les pages générées par scaffolding et créons-en de nouvelles pour ces deux cas de figure.
 
-Nous avons déjà la `HomePage`, pas besoin de créer celle-ci donc. Nous souhaitons afficher une liste d'articles à l'utilisateur donc nous allons devoir ajouter ça. Nous avons besoin de récupérer le contenu depuis la base de données, et nous ne voulons pas que l'utilisateur soit face à une page blanche le temps du chargement (conditions réseau dégradées, serveur géographiquement distant, etc...), donc nous voudrons montrer une sorte de message de chargement et/ou une animation. D'autre part, si une erreur se produit, nous devrons faire en sorte de la prendre en charge. Enfin, nous devrons également prendre en compte le cas où le blog ne contient encore aucun article. 
+Nous avons déjà la `HomePage`, pas besoin de créer celle-ci donc. Nous souhaitons afficher une liste d'articles à l'utilisateur donc nous allons devoir ajouter ça. Nous avons besoin de récupérer le contenu depuis la base de données, et nous ne voulons pas que l'utilisateur soit face à une page blanche le temps du chargement (conditions réseau dégradées, serveur géographiquement distant, etc...), donc nous voudrons montrer une sorte de message de chargement et/ou une animation. D'autre part, si une erreur se produit, nous devrons faire en sorte de la prendre en charge. Enfin, nous devrons également prendre en compte le cas où le blog ne contient encore aucun article.
 
-Wow... notre première page et il semble que nous ayons déjà à nous inquiéter de tant de choses... mais est-ce véritablement le cas ? 
-
+Wow... notre première page et il semble que nous ayons déjà à nous inquiéter de tant de choses... mais est-ce véritablement le cas ?

--- a/to-upload/fr/layouts.md
+++ b/to-upload/fr/layouts.md
@@ -22,70 +22,70 @@ Ce faisant, nous avons créé le fichier `web/src/layouts/BlogLayout/BlogLayout.
 
 Supprimez ce `<header>` de `HomePage` et `AboutPage` et copier son contenu à l'intérieur du layout. Supprimons également le doublon de la balise `<main>` par la même occasion.
 
-```javascript{3,7-19}
+```javascript {3,7-19}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const BlogLayout = ({ children }) => {
-  return (
-    <>
-      <header>
-        <h1>Redwood Blog</h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>{children}</main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>Redwood Blog</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>{children}</main>
+		</>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 `children` est l'endroit où la magie opère! Toute page passée en argument à un layout s'affiche là. Pour en revenir à `HomePage` et `AboutPage`, en les entourant simplement au sein du `<BlogLayout>`, nos deux pages ne font désormais que ce qu'elles sont supposées faire: afficher leur contenu. Nous pouvons maintenant supprimer les imports de `Link`et `Route` puisqu'ils figurent également dans le Layout.
 
-```javascript{3,6}
+```javascript {3,6}
 // web/src/pages/HomePage/HomePage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
+import BlogLayout from "src/layouts/BlogLayout";
 
 const HomePage = () => {
-  return <BlogLayout>Home</BlogLayout>
-}
+	return <BlogLayout>Home</BlogLayout>;
+};
 
-export default HomePage
+export default HomePage;
 ```
 
-```javascript{4,8-14}
+```javascript {4,8-14}
 // web/src/pages/AboutPage/AboutPage.js
 
-import { Link, routes } from '@redwoodjs/router'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Link, routes } from "@redwoodjs/router";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const AboutPage = () => {
-  return (
-    <BlogLayout>
-        <p>
-          Ce site est créé avec pour seule intention de démontrer la puissance créative de Redwood! Oui, c'est très 
-          impressionant :D
-        </p>
-      <Link to={routes.home()}>Return home</Link>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<p>
+				Ce site est créé avec pour seule intention de démontrer la puissance créative de Redwood! Oui, c'est très
+				impressionant :D
+			</p>
+			<Link to={routes.home()}>Return home</Link>
+		</BlogLayout>
+	);
+};
 
-export default AboutPage
+export default AboutPage;
 ```
 
 > **L'alias `src`**
 >
-> Remarquez que l'import utilise `src/layouts/BlogLayout` et non `../src/layouts/BlogLayout` ou `./src/layouts/BlogLayout`. Pouvoir se contenter d'ajouter uniquement `src` est un petit apport bien pratique de Redwood: `src` est un alias pour le chemin du répertoire `src` du workspace courant. En d'autres termes, lorsque vous travaillez dans `web`, `src` pointe vers `web/src`. Et lorsque vous travaillez dans `api` il pointe vers `api/src`. 
+> Remarquez que l'import utilise `src/layouts/BlogLayout` et non `../src/layouts/BlogLayout` ou `./src/layouts/BlogLayout`. Pouvoir se contenter d'ajouter uniquement `src` est un petit apport bien pratique de Redwood: `src` est un alias pour le chemin du répertoire `src` du workspace courant. En d'autres termes, lorsque vous travaillez dans `web`, `src` pointe vers `web/src`. Et lorsque vous travaillez dans `api` il pointe vers `api/src`.
 
 Revenez donc dans votre navigateur, et vous devriez alors voir...... rien de nouveau. Et c'est très bien! Votre layout fonctionne parfaitement.
 
@@ -103,32 +103,32 @@ Revenez donc dans votre navigateur, et vous devriez alors voir...... rien de nou
 
 Ajoutons encore un autre `<Link>` de façon à ce que le titre et le logo pointent vers la page d'accueil:
 
-```javascript{9-11}
+```javascript {9-11}
 // web/src/layouts/BlogLayout/BlogLayout.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 const BlogLayout = ({ children }) => {
-  return (
-    <>
-      <header>
-        <h1>
-          <Link to={routes.home()}>Redwood Blog</Link>
-        </h1>
-        <nav>
-          <ul>
-            <li>
-              <Link to={routes.about()}>About</Link>
-            </li>
-          </ul>
-        </nav>
-      </header>
-      <main>{children}</main>
-    </>
-  )
-}
+	return (
+		<>
+			<header>
+				<h1>
+					<Link to={routes.home()}>Redwood Blog</Link>
+				</h1>
+				<nav>
+					<ul>
+						<li>
+							<Link to={routes.about()}>About</Link>
+						</li>
+					</ul>
+				</nav>
+			</header>
+			<main>{children}</main>
+		</>
+	);
+};
 
-export default BlogLayout
+export default BlogLayout;
 ```
 
 Enfin nous pouvons éliminer de la page About le lien "Retour à la page d'accueil" devenu superflu (ainsi que les imports `Link` et `routes` associés).
@@ -136,18 +136,18 @@ Enfin nous pouvons éliminer de la page About le lien "Retour à la page d'accue
 ```javascript
 // web/src/pages/AboutPage/AboutPage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
+import BlogLayout from "src/layouts/BlogLayout";
 
 const AboutPage = () => {
-  return (
-    <BlogLayout>
-      <p>
-        Ce site est créé avec pour seule intention de démontrer la puissance créative de Redwood! Oui, c'est très 
-        impressionant :D
-      </p>
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<p>
+				Ce site est créé avec pour seule intention de démontrer la puissance créative de Redwood! Oui, c'est très
+				impressionant :D
+			</p>
+		</BlogLayout>
+	);
+};
 
-export default AboutPage
+export default AboutPage;
 ```

--- a/to-upload/fr/routing-params.md
+++ b/to-upload/fr/routing-params.md
@@ -12,26 +12,26 @@ Maintenant que notre page d'accueil liste l'ensemble des articles de notre blog,
 
 Pour chaque article listé sur la page d'accueil, ajoutons un lien qui pointe vers notre nouvelle page (sans oublier au passage les imports pour `Link` et `routes`):
 
-```javascript{3,12}
+```javascript {3,12}
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
-import { Link, routes } from '@redwoodjs/router'
+import { Link, routes } from "@redwoodjs/router";
 
 // QUERY, Loading, Empty and Failure definitions...
 
 export const Success = ({ posts }) => {
-  return posts.map((post) => (
-    <article key={post.id}>
-      <header>
-        <h2>
-          <Link to={routes.blogPost()}>{post.title}</Link>
-        </h2>
-      </header>
-      <p>{post.body}</p>
-      <div>Créé le: {post.createdAt}</div>
-    </article>
-  ))
-}
+	return posts.map((post) => (
+		<article key={post.id}>
+			<header>
+				<h2>
+					<Link to={routes.blogPost()}>{post.title}</Link>
+				</h2>
+			</header>
+			<p>{post.body}</p>
+			<div>Créé le: {post.createdAt}</div>
+		</article>
+	));
+};
 ```
 
 Si vous cliquez sur le lien, vous deviez voir s'afficher un peu de texte issu de `BlogPostPage`. Mais ce dont nous avons vraiment besoin, c'est de pouvoir préciser _quel_ article nous souhaitons afficher. Ce que nous cherchons a obtenir en définitive, c'est une URL du type `/blog-post/1`. Pour cela, nous allons dire au routeur que notre url comporte une partie variable supplémentaire:
@@ -39,7 +39,7 @@ Si vous cliquez sur le lien, vous deviez voir s'afficher un peu de texte issu de
 ```html
 // web/src/Routes.js
 
-<Route path="/blog-post/{id}" page={BlogPostPage} name="blogPost" />
+<Route path="/blog-post/{id}" page="{BlogPostPage}" name="blogPost" />
 ```
 
 Notez l'ajout de `{id}` dans notre route. Redwood nomme ceci un _paramètre de route_. Ces paramètres de route signifie la chose suivante: "quelque soit la valeur à cette position, elle sera référencée par le nom utilisé entre les accolades".
@@ -65,59 +65,59 @@ Nous allons ensuite utiliser cette Cell dans notre page `BlogPostPage` (et penda
 ```javascript
 // web/src/pages/BlogPostPage/BlogPostPage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
-import BlogPostCell from 'src/components/BlogPostCell'
+import BlogLayout from "src/layouts/BlogLayout";
+import BlogPostCell from "src/components/BlogPostCell";
 
 const BlogPostPage = () => {
-  return (
-    <BlogLayout>
-      <BlogPostCell />
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<BlogPostCell />
+		</BlogLayout>
+	);
+};
 
-export default BlogPostPage
+export default BlogPostPage;
 ```
 
 Maintenant, à l'intérieur de notre Cell, nous avons besoin d'accéder à ce paramètre de route `{id}` qui contient l'identifiant de notre article en base de données. Pour ce faire, mettons à jour la requête de façon à ce qu'elle accepte une variable en entrée. Modifions également le nom de la requête `blogPost` en `post`.
 
-```javascript{4,5,7-9,20,21}
+```javascript {4,5,7-9,20,21}
 // web/src/components/BlogPostCell/BlogPostCell.js
 
 export const QUERY = gql`
-  query BlogPostQuery($id: Int!) {
-    post(id: $id) {
-      id
-      title
-      body
-      createdAt
-    }
-  }
-`
+	query BlogPostQuery($id: Int!) {
+		post(id: $id) {
+			id
+			title
+			body
+			createdAt
+		}
+	}
+`;
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <div>Loading...</div>;
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <div>Empty</div>;
 
-export const Failure = ({ error }) => <div>Error: {error.message}</div>
+export const Failure = ({ error }) => <div>Error: {error.message}</div>;
 
 export const Success = ({ post }) => {
-  return JSON.stringify(post)
-}
+	return JSON.stringify(post);
+};
 ```
 
 Okay, on approche du but! Ceci étant, d'où vient donc ce `$id`? Redwood a plus d'un tour dans son sac. Chaque fois que vous ajoutez un paramètre de route, ce paramètre est automatiquement accessible dans la page qui correspond. Ce qui signifie que vous pouvez modifier la page `BlogPostPage` de la façon suivante:
 
-```javascript{3,6}
+```javascript {3,6}
 // web/src/pages/BlogPostPage/BlogPostPage.js
 
 const BlogPostPage = ({ id }) => {
-  return (
-    <BlogLayout>
-      <BlogPostCell id={id} />
-    </BlogLayout>
-  )
-}
+	return (
+		<BlogLayout>
+			<BlogPostCell id={id} />
+		</BlogLayout>
+	);
+};
 ```
 
 `id` existe déjà sans effort supplémentaire puisque nous avons nommé notre paramètre de route `{id}`. Merci qui? Merci Redwood! Mais comment se fait-il que cet `id` finisse par devenir un paramètre GraphQL `$id`? Redwood s'en charge également pour vous! Par défaut, chaque propriété que vous donnez à une Cell devient automatiquement un variable disponible pour une requête GraphQL. Incroyablement simple, et pourtant vrai :)
@@ -134,7 +134,7 @@ Si vous examinez la console de votre navigateur, vous constaterez la présence d
       Expected type Int. Int cannot represent non-integer value: "1",
       Location: [object Object], Path: undefined
 
-Il s'avère que les paramètres de route sont extraits des URL sous la forme de chaînes de caractères, et dans le cas présent GraphQL s'attend à recevoir un identifiant sous la forme d'un entier. Nous pourrions simplement utiliser la fonction javascript `parseInt()` afin de convertir notre paramètre de route vers un entier avant de le passer à `BlogPostCell`. Mais honnêtement, on peut faire bien mieux que ça! 
+Il s'avère que les paramètres de route sont extraits des URL sous la forme de chaînes de caractères, et dans le cas présent GraphQL s'attend à recevoir un identifiant sous la forme d'un entier. Nous pourrions simplement utiliser la fonction javascript `parseInt()` afin de convertir notre paramètre de route vers un entier avant de le passer à `BlogPostCell`. Mais honnêtement, on peut faire bien mieux que ça!
 
 ### Paramètres de Route Typés
 
@@ -144,7 +144,7 @@ What if you could request the conversion right in the route's path? Well, guess 
 ```html
 // web/src/Routes.js
 
-<Route path="/blog-post/{id:Int}" page={BlogPostPage} name="blogPost" />
+<Route path="/blog-post/{id:Int}" page="{BlogPostPage}" name="blogPost" />
 ```
 
 Voilà! Non seulement vous allez convertir sans effort le paramètre `id` en un entier avant de la passer à votre Page, mais en bonus vous faîtes en sorte que la route n'applique que si `id` représente effectivement un entier, c'est à dire une suite de chiffres. Dans le cas contraire, le routeur essaiera d'autres routes. S'il ne s'en trouve aucune à s'appliquer, le routeur affichera la page `NotFoundPage`.
@@ -156,14 +156,14 @@ Voilà! Non seulement vous allez convertir sans effort le paramètre `id` en un 
 > ```javascript
 > <BlogPostCell id={id} rand={Math.random()} />
 > ```
-> 
+>
 > Et ensuite vous la récupérez avec le résulat de la requête ans le composant (et même avec l'identifiant de l'article si vous le souhaitez):
 > And get it, along with the query result (and even the original `id` if you want) in the component:
 >
 > ```javascript
 > export const Success = ({ post, id, rand }) => {
->   //...
-> }
+> 	//...
+> };
 > ```
 >
 > Merci Redwood!
@@ -174,21 +174,21 @@ Maintenant, affichons un véritable article au lieu d'un simple dump du résulta
 
     yarn rw g component BlogPost
 
-L'exécution de cette commande créé le composant `BlogPost` dans le fichier `web/src/components/BlogPost/BlogPost.js`, accompagné de son fichier de test: 
+L'exécution de cette commande créé le composant `BlogPost` dans le fichier `web/src/components/BlogPost/BlogPost.js`, accompagné de son fichier de test:
 
 ```javascript
 // web/src/components/BlogPost/BlogPost.js
 
 const BlogPost = () => {
-  return (
-    <div>
-      <h2>{'BlogPost'}</h2>
-      <p>{'Find me in ./web/src/components/BlogPost/BlogPost.js'}</p>
-    </div>
-  )
-}
+	return (
+		<div>
+			<h2>{"BlogPost"}</h2>
+			<p>{"Find me in ./web/src/components/BlogPost/BlogPost.js"}</p>
+		</div>
+	);
+};
 
-export default BlogPost
+export default BlogPost;
 ```
 
 > Vous remarquerez peut-être que nous n'avons ici aucun `import` relatif à la librairie `React`. Il s'agit pourtant bien d'un classique composant React. En réalité, nous (la "Redwood dev team") sommes un peu fatigués d'avoir à importer constamment les mêmes fichiers de la même manière... alors nous avons fait en sorte que Redwood le fasse pour nous, et donc pour vous!
@@ -244,7 +244,7 @@ export const Success = ({ post }) => {
 
 Et nous y sommes! Nous devrions maintenant pouvoir aller et venir à notre guise entre la page d'accueil et les articles.
 
-> Si vous appréciez ce que vous venez de voir sur le routeur, vous pouvez en apprendre plus dans le [guide](https://redwoodjs.com/docs/redwood-router) qui lui est consacré. 
+> Si vous appréciez ce que vous venez de voir sur le routeur, vous pouvez en apprendre plus dans le [guide](https://redwoodjs.com/docs/redwood-router) qui lui est consacré.
 
 ### Résumé
 
@@ -254,4 +254,4 @@ Un petit état des lieux de ce que nous avons réalisé:
 2. Ajout d'une route prenant en char l'identifiant `id` d'un article sous la forme d'un paramètre de route
 3. Création d'une Cell permettant de récupérer et afficher un article
 4. Constat de la capacité de Redwood à vous mettre de bonne humeur en vous donnant accès à `id` là où vous en avez besoin tout en le convertissant au format numérique à la volée
-6. Transformation de l'affichage d'un article en un composant React classique pouvant être partagé à plusieurs endroits dans l'interface (en l'espèce dans la page d'accueil et la page de détail)
+5. Transformation de l'affichage d'un article en un composant React classique pouvant être partagé à plusieurs endroits dans l'interface (en l'espèce dans la page d'accueil et la page de détail)

--- a/to-upload/fr/saving-data.md
+++ b/to-upload/fr/saving-data.md
@@ -4,7 +4,7 @@ title: "Enregistrer les Données"
 sidebar_label: "Enregistrer les Données"
 ---
 
-Ajoutons une nouvelle table à notre base de données. Ouvrez `api/prisma/schema.prisma` et ajoutez un nouveau modèle "Contact" à la suite du premier modèle "Post": 
+Ajoutons une nouvelle table à notre base de données. Ouvrez `api/prisma/schema.prisma` et ajoutez un nouveau modèle "Contact" à la suite du premier modèle "Post":
 
 ```javascript
 // api/prisma/schema.prisma
@@ -18,7 +18,7 @@ model Contact {
 }
 ```
 
-> Pour définir une colonne comme optionnelle (c'est à dire permettre que sa valeur soit `NULL`), il suffit de suffixer le type de la donnée avec un point d'interrogation: `name String?` 
+> Pour définir une colonne comme optionnelle (c'est à dire permettre que sa valeur soit `NULL`), il suffit de suffixer le type de la donnée avec un point d'interrogation: `name String?`
 
 Nous créons ensuite notre nouvelle migration:
 
@@ -43,43 +43,43 @@ Ouvrez `api/src/graphql/contacts.sdl.js` et vous verrez les types `Contact`, `Cr
 // api/src/graphql/contacts.sdl.js
 
 export const schema = gql`
-  type Contact {
-    id: Int!
-    name: String!
-    email: String!
-    message: String!
-    createdAt: DateTime!
-  }
+	type Contact {
+		id: Int!
+		name: String!
+		email: String!
+		message: String!
+		createdAt: DateTime!
+	}
 
-  type Query {
-    contacts: [Contact!]!
-  }
+	type Query {
+		contacts: [Contact!]!
+	}
 
-  input CreateContactInput {
-    name: String!
-    email: String!
-    message: String!
-  }
+	input CreateContactInput {
+		name: String!
+		email: String!
+		message: String!
+	}
 
-  input UpdateContactInput {
-    name: String
-    email: String
-    message: String
-  }
-`
+	input UpdateContactInput {
+		name: String
+		email: String
+		message: String
+	}
+`;
 ```
 
 Que sont les "input" `CreateContactInput` et `UpdateContactInput`? Redwood suit la recommandation de GraphQL d'utiliser les [Input Types](https://graphql.org/graphql-js/mutations-and-input-types/) dans les mutations plutôt que de lister tous les champs qui peuvent être définis. Tous les champs requis dans `schema.prisma` sont également requis dans `CreateContactInput` (vous ne pouvez pas créer un enregistrement valide sans eux) mais rien n'est explicitement requis dans `UpdateContactInput`. En effet, vous pouvez souhaiter mettre à jour un seul champ, deux champs ou tous les champs. L'alternative serait de créer des types d'entrée séparés pour chaque permutation de champs que vous souhaitez mettre à jour. Nous avons estimé que le fait de n'avoir qu'une seule entrée de mise à jour, bien que ce ne soit peut-être pas la manière absolument correcte de créer une API GraphQL, était un bon compromis pour faciliter le développement.
 
-> Redwood suppose que votre code n'essaiera pas de définir une valeur sur un champ nommé `id` ou `createdAt` donc il les a laissés en dehors des types d'entrée, mais si votre base de données autorise l'un ou l'autre de ceux à définir manuellement, vous pouvez mettre à jour` CreateContactInput `ou `UpdateContactInput` et les ajouter.
+> Redwood suppose que votre code n'essaiera pas de définir une valeur sur un champ nommé `id` ou `createdAt` donc il les a laissés en dehors des types d'entrée, mais si votre base de données autorise l'un ou l'autre de ceux à définir manuellement, vous pouvez mettre à jour`CreateContactInput`ou `UpdateContactInput` et les ajouter.
 
 Puisque toutes les colonnes de la table étaient définies comme requises dans `schema.prisma`, elles sont également définies comme requises ici (notez le suffixe `!` sur les types de données)
 
 > **important:** la syntaxe de `schema.prisma` requiert l'ajout d'un caractère `?` lorsqu'un champ _n'est pas_ requis, tandis que la syntaxe GraphQL requiert l'ajout d'un caractère `!` lorsqu'un champ _est_ requis.
 
-Comme décrit dans [Quête secondaire: Fonctionnement de Redwood avec les Données](qu-te-secondaire-fonctionnement-de-redwood-avec-les-donn-es), il n'y a pas de "resolver" définit explicitement dans le fichier SDL. Redwood suit une convention de nommage simple: chaque champ listé dans les types `Query` et `Mutation` correspondent à une fonction avec un nom identique dans les fichiers `service` et `sdl` associés (`api/src/graphql/contacts.sdl.js -> api/src/services/contacts/contacts.js`) 
+Comme décrit dans [Quête secondaire: Fonctionnement de Redwood avec les Données](qu-te-secondaire-fonctionnement-de-redwood-avec-les-donn-es), il n'y a pas de "resolver" définit explicitement dans le fichier SDL. Redwood suit une convention de nommage simple: chaque champ listé dans les types `Query` et `Mutation` correspondent à une fonction avec un nom identique dans les fichiers `service` et `sdl` associés (`api/src/graphql/contacts.sdl.js -> api/src/services/contacts/contacts.js`)
 
-Dans le cas présent, nous créeons une unique `Mutation` que nous appelons `createContact`. Nous l'ajoutons à la fin de notre fichier SDL (avant le caractère 'backtick'): 
+Dans le cas présent, nous créeons une unique `Mutation` que nous appelons `createContact`. Nous l'ajoutons à la fin de notre fichier SDL (avant le caractère 'backtick'):
 
 ```javascript
 // api/src/graphql/contacts.sdl.js
@@ -93,18 +93,18 @@ La mutation `createContact` accepte une variable unique, `input`, qui est un obj
 
 C'est terminé pour le fichier SDL, définissons maintenant le service qui va réellement enregistrer les données en base. Le service inclut une fonction `contacts` permettant de récupérer l'ensemble des contacts depuis la base. Ajoutons-y une mutation pour pouvoir créer un nouveau contact:
 
-```javascript{9-11}
+```javascript {9-11}
 // api/src/services/contacts/contacts.js
 
-import { db } from 'src/lib/db'
+import { db } from "src/lib/db";
 
 export const contacts = () => {
-  return db.contact.findMany()
-}
+	return db.contact.findMany();
+};
 
 export const createContact = ({ input }) => {
-  return db.contact.create({ data: input })
-}
+	return db.contact.create({ data: input });
+};
 ```
 
 Grâce au client Prisma, il faut peu de code pour enregistrer nos données en base! Il s'agit d'un appel asynchrone, mais nous n'avons pas à nous soucier de manipuler un objet Promise ou s'arranger avec `async/await`. La librairie Apollo le fait pour nous!
@@ -115,7 +115,7 @@ Avant d'insérer tout ceci dans notre interface utilisateur, prennons un peu de 
 
 Souvent, il est utile d'expérimenter notre API dans une forme un peu "brute" avant de poursuivre plus avant le développement de l'interface et s'apercevoir que l'on a oublié quelque chose.
 
-Lorsque vous avez exécuté la commande `yarn redwood dev` au début de ce didacticiel, vous avez en réalité démarré un second processus en arrière-plan. Ouvrez donc une nouvelle page de votre navigateur à cette adresse: http://localhost:8911/graphql . Il s'agit du [Bac à Sable GraphQL](https://github.com/prisma-labs/graphql-playground) fournit par la librairie Prisma, une application web permettant d'interagir avec une API GraphQL: 
+Lorsque vous avez exécuté la commande `yarn redwood dev` au début de ce didacticiel, vous avez en réalité démarré un second processus en arrière-plan. Ouvrez donc une nouvelle page de votre navigateur à cette adresse: http://localhost:8911/graphql . Il s'agit du [Bac à Sable GraphQL](https://github.com/prisma-labs/graphql-playground) fournit par la librairie Prisma, une application web permettant d'interagir avec une API GraphQL:
 
 <img src="https://user-images.githubusercontent.com/300/70950852-9b97af00-2016-11ea-9550-b6983ce664e2.png" />
 
@@ -137,19 +137,19 @@ Notre mutation GraphQL est prête pour la partie backend, tout ce qu'il reste à
 // web/src/pages/ContactPage/ContactPage.js
 
 const CREATE_CONTACT = gql`
-  mutation CreateContactMutation($input: CreateContactInput!) {
-    createContact(input: $input) {
-      id
-    }
-  }
-`
+	mutation CreateContactMutation($input: CreateContactInput!) {
+		createContact(input: $input) {
+			id
+		}
+	}
+`;
 ```
 
 Nous référençons ainsi la mutation `createContact` définie auparavant dans le fichier SDL des contacts, tout en lui passant en argument un objet `input` contenant la valeur des champs `name`, `email` et `message`.
 
 Après quoi, nous appelons le 'hook' `useMutation` fourni par Appolo, ce qui nous permet d'exécuter la mutation lorsque le moment est venu (n'oubliez pas les imports comme à chaque fois):
 
-```javascript{11,15}
+```javascript {11,15}
 // web/src/pages/ContactPage/ContactPage.js
 
 import {
@@ -173,25 +173,26 @@ const ContactPage = () => {
   return (...)
 }
 ```
+
 `create` est une fonction qui invoque la mutation et prend en paramètre un objet contenant un clef `variables`. Cette dernière contient à son tour une clef `input`. Par exemple, nous pourrions l'appeler également de cette manière:
 
 ```javascript
 create({
-  variables: {
-    input: {
-      name: 'Rob',
-      email: 'rob@redwoodjs.com',
-      message: 'I love Redwood!',
-    },
-  },
-})
+	variables: {
+		input: {
+			name: "Rob",
+			email: "rob@redwoodjs.com",
+			message: "I love Redwood!",
+		},
+	},
+});
 ```
 
-Si votre méémoire est bonne, vous vous souvenez sans doute que la balise `<Form>` nous donne accès à l'ensemble des champs du formulaire avec un objet bien pratique dans lequel chaque clef se trouve être le nom du champ. Celà signifie donc que l'objet `data`que nous recevons dans `onSubmit` est déjà dans le format adapté pour `input`!  
+Si votre méémoire est bonne, vous vous souvenez sans doute que la balise `<Form>` nous donne accès à l'ensemble des champs du formulaire avec un objet bien pratique dans lequel chaque clef se trouve être le nom du champ. Celà signifie donc que l'objet `data`que nous recevons dans `onSubmit` est déjà dans le format adapté pour `input`!
 
 Maintenant nous pouvons mettre à jour la fonction `onSubmit` pour invoquer la mutation avec les données qu'elle reçoit:
 
-```javascript{7}
+```javascript {7}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
@@ -222,7 +223,7 @@ Essayons d'y apporter une solution.
 
 Le 'hook' `useMutation` retourne quelques autres éléments en plus de la fonction permettant de l'invoquer. Nous pouvons déstructurer ceux-ci (`loading` et `error`) de la façon suivante:
 
-```javascript{4}
+```javascript {4}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
@@ -257,7 +258,7 @@ Vous verrez alors que le bouton "Save" devient inactif pendant une seconde ou de
 
 Maintenant, utilisons le système dit de `Flash` proposé par Redwood afin d'informer l'utilisateur que son envoi à bien été traité. `useMutation` accepte un second paramètre optionnel contenant des options. Une de ces options est une fonction callback appelée `onCompleted` qui sera invoquée lorsque la mutation sera achevée avec succès. Nous allons donc utiliser cette fonction pour ajouter un message qui sera affiché par un composant `Flash`. Ajoutez donc le composant `Flash` a votre page et utilisez sa propriété `timeout` pour définir le temps d'affichage. (Vous pouvez lire la documentation à propos du système de Flash proposé par Redwood [ici](https://redwoodjs.com/docs/flash-messaging-bus))
 
-```javascript{4,10,13-17,24}
+```javascript {4,10,13-17,24}
 // web/src/pages/ContactPage/ContactPage.js
 
 // ...
@@ -291,44 +292,44 @@ Nous allons maintenant informer l'utilisateur des éventuelles erreurs côté se
 
 Ainsi, nous avons une validateur de l'email côté client, mais tout bon développeur web sait qu'il ne faut [_jamais faire confiance au client_](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Ajoutons une validation de l'email côté serveur de façon à être certain qu'aucune donnée erronée ne soit ajoutée dans la base, et ce même si un utilisateur parvenait à contourner le fonctionnement de l'application côté client.
 
-> Pourquoi n'avons-nous pas besoin de validation côté serveur pour s'assurer que les champs name, email et message sont bien remplis? Car la base de données le fait pour nous. Vous rappellez-vous `String!` dans notre fichier SDL? Celà ajoute une contrainte en base de données de telle façon que ce champ ne puisse être `null`. Une valeur `null` serait rejetée par la base et GraphQL renverrait une erreur à la partie client. 
+> Pourquoi n'avons-nous pas besoin de validation côté serveur pour s'assurer que les champs name, email et message sont bien remplis? Car la base de données le fait pour nous. Vous rappellez-vous `String!` dans notre fichier SDL? Celà ajoute une contrainte en base de données de telle façon que ce champ ne puisse être `null`. Une valeur `null` serait rejetée par la base et GraphQL renverrait une erreur à la partie client.
 >
-> Cependant, il n'existe pas de type `Email!`, raison pour laquelle nous devons assurer la validation nous même 
+> Cependant, il n'existe pas de type `Email!`, raison pour laquelle nous devons assurer la validation nous même
 
 Nous avons déjà parlé de code métier et du fait que ce type de code a vocation à se trouver dans nos fichiers services. Ceci en est un exemple parfait. Ajoutons une fonction `validate` à notre service `contacts`:
 
-```javascript{3,7-15,22}
+```javascript {3,7-15,22}
 // api/src/services/contacts/contacts.js
 
-import { UserInputError } from '@redwoodjs/api'
+import { UserInputError } from "@redwoodjs/api";
 
-import { db } from 'src/lib/db'
+import { db } from "src/lib/db";
 
 const validate = (input) => {
-  if (input.email && !input.email.match(/[^@]+@[^.]+\..+/)) {
-    throw new UserInputError("Can't create new contact", {
-      messages: {
-        email: ['is not formatted like an email address'],
-      },
-    })
-  }
-}
+	if (input.email && !input.email.match(/[^@]+@[^.]+\..+/)) {
+		throw new UserInputError("Can't create new contact", {
+			messages: {
+				email: ["is not formatted like an email address"],
+			},
+		});
+	}
+};
 
 export const contacts = () => {
-  return db.contact.findMany()
-}
+	return db.contact.findMany();
+};
 
 export const createContact = ({ input }) => {
-  validate(input)
-  return db.contact.create({ data: input })
-}
+	validate(input);
+	return db.contact.create({ data: input });
+};
 ```
 
 Ainsi, lorsque `createContact` est invoquée, la fonction commence par valider le contenu des champs du formulaire. Puis, et seulement s'il n'y a aucune erreur, l'enregistrement sera créé en base de données.
 
 Nous capturons déjà toutes les erreurs dans la constante `error` que nous obtenons grâce au 'hook' `useMutation`. C'est pourquoi nous avons la possibilité d'afficher ces erreurs sur la page, par exemple au dessus du formulaire:
 
-```html{4-9}
+```html {4-9}
 // web/src/pages/ContactPage/ContactPage.js
 
 <Form onSubmit={onSubmit} validation={{ mode: 'onBlur' }}>
@@ -358,15 +359,8 @@ Nous capturons déjà toutes les erreurs dans la constante `error` que nous obte
 Afin de tester ceci, provoquons une erreur en retirant temporairement la validation côté client de l'adresse email:
 
 ```html
-// web/src/pages/ContactPage/ContactPage.js
-
-<TextField
-  name="email"
-  validation={{
-    required: true,
-  }}
-  errorClassName="error"
-/>
+// web/src/pages/ContactPage/ContactPage.js <TextField name="email" validation={{ required: true, }}
+errorClassName="error" />
 ```
 
 Maintenant, essayons de remplir le formulaire avec un adresse invalide:
@@ -379,7 +373,7 @@ Vous rapellez-vous lorsque nous avons dit que `<Form>` avait plus d'un tour dans
 
 Supprimez l'affichage de l'erreur tel que nous venons de l'ajouter (`{ error && ...}`) , et remplacez-le avec `<FormError>` tout en passant en argument la constante `error` que nous récupérons depuis `useMutation`. Ajoutez également quelques ééléments de style à `wrapperStyle`, sans oublier les `import` associés.
 
-```javascript{10,18-22}
+```javascript {10,18-22}
 // web/src/pages/ContactPage/ContactPage.js
 
 import {
@@ -431,12 +425,12 @@ Commençons par importer `useForm`:
 ```javascript
 // web/src/pages/ContactPage/ContactPage.js
 
-import { useForm } from 'react-hook-form'
+import { useForm } from "react-hook-form";
 ```
 
 Puis invoquons ce 'hook' dans notre composant:
 
-```javascript{4}
+```javascript {4}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
@@ -446,7 +440,7 @@ const ContactPage = () => {
 
 Enfin, donnons pour instruction explicite à `<Form>` d'utiliser `formMethods`, au lieu de le laisser le faire lui-même:
 
-```javascript{10}
+```javascript {10}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
@@ -467,119 +461,95 @@ Maintenant nous pouvons invoquer manuellement `reset()` depuis `formMethods()` j
 // web/src/pages/ContactPage/ContactPage.js
 
 const [create, { loading, error }] = useMutation(CREATE_CONTACT, {
-  onCompleted: () => {
-    // addMessage...
-    formMethods.reset()
-  },
-})
+	onCompleted: () => {
+		// addMessage...
+		formMethods.reset();
+	},
+});
 ```
 
 <img alt="Capture écran du formulaire de Contact avec message de confirmation Flash" src="https://user-images.githubusercontent.com/44448047/93649232-1be9a700-f9d1-11ea-821c-7a69c626f50c.png" />
 
 > Vous pouvez maintenant réactiver la validation email côté client sur le `<TextField>`, tout en conservant la validation côté serveur.
 
-Voici le contenu final de la page `ContactPage.js`: 
+Voici le contenu final de la page `ContactPage.js`:
 
 ```javascript
-import {
-  Form,
-  TextField,
-  TextAreaField,
-  Submit,
-  FieldError,
-  Label,
-  FormError,
-} from '@redwoodjs/forms'
-import { Flash, useFlash, useMutation } from '@redwoodjs/web'
-import { useForm } from 'react-hook-form'
-import BlogLayout from 'src/layouts/BlogLayout'
+import { Form, TextField, TextAreaField, Submit, FieldError, Label, FormError } from "@redwoodjs/forms";
+import { Flash, useFlash, useMutation } from "@redwoodjs/web";
+import { useForm } from "react-hook-form";
+import BlogLayout from "src/layouts/BlogLayout";
 
 const CREATE_CONTACT = gql`
-  mutation CreateContactMutation($input: CreateContactInput!) {
-    createContact(input: $input) {
-      id
-    }
-  }
-`
+	mutation CreateContactMutation($input: CreateContactInput!) {
+		createContact(input: $input) {
+			id
+		}
+	}
+`;
 
 const ContactPage = () => {
-  const formMethods = useForm()
-  const { addMessage } = useFlash()
+	const formMethods = useForm();
+	const { addMessage } = useFlash();
 
-  const [create, { loading, error }] = useMutation(CREATE_CONTACT, {
-    onCompleted: () => {
-      addMessage('Thank you for your submission!', {
-        style: { backgroundColor: 'green', color: 'white', padding: '1rem' }
-      })
-      formMethods.reset()
-    },
-  })
+	const [create, { loading, error }] = useMutation(CREATE_CONTACT, {
+		onCompleted: () => {
+			addMessage("Thank you for your submission!", {
+				style: { backgroundColor: "green", color: "white", padding: "1rem" },
+			});
+			formMethods.reset();
+		},
+	});
 
-  const onSubmit = (data) => {
-    create({ variables: { input: data } })
-    console.log(data)
-  }
+	const onSubmit = (data) => {
+		create({ variables: { input: data } });
+		console.log(data);
+	};
 
-  return (
-    <BlogLayout>
-      <Flash timeout={1000} />
-      <Form
-        onSubmit={onSubmit}
-        validation={{ mode: 'onBlur' }}
-        error={error}
-        formMethods={formMethods}
-      >
-        <FormError
-          error={error}
-          wrapperStyle={{ color: 'red', backgroundColor: 'lavenderblush' }}
-        />
-        <Label name="name" errorClassName="error">
-          Name
-        </Label>
-        <TextField
-          name="name"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="name" className="error" />
+	return (
+		<BlogLayout>
+			<Flash timeout={1000} />
+			<Form onSubmit={onSubmit} validation={{ mode: "onBlur" }} error={error} formMethods={formMethods}>
+				<FormError error={error} wrapperStyle={{ color: "red", backgroundColor: "lavenderblush" }} />
+				<Label name="name" errorClassName="error">
+					Name
+				</Label>
+				<TextField name="name" validation={{ required: true }} errorClassName="error" />
+				<FieldError name="name" className="error" />
 
-        <Label name="name" errorClassName="error">
-          Email
-        </Label>
-        <TextField
-          name="email"
-          validation={{
-            required: true,
-          }}
-          errorClassName="error"
-        />
-        <FieldError name="email" className="error" />
+				<Label name="name" errorClassName="error">
+					Email
+				</Label>
+				<TextField
+					name="email"
+					validation={{
+						required: true,
+					}}
+					errorClassName="error"
+				/>
+				<FieldError name="email" className="error" />
 
-        <Label name="name" errorClassName="error">
-          Message
-        </Label>
-        <TextAreaField
-          name="message"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="message" className="error" />
+				<Label name="name" errorClassName="error">
+					Message
+				</Label>
+				<TextAreaField name="message" validation={{ required: true }} errorClassName="error" />
+				<FieldError name="message" className="error" />
 
-        <Submit disabled={loading}>Save</Submit>
-      </Form>
-    </BlogLayout>
-  )
-}
+				<Submit disabled={loading}>Save</Submit>
+			</Form>
+		</BlogLayout>
+	);
+};
 
-export default ContactPage
+export default ContactPage;
 ```
 
-C'est terminé! [React Hook Form](https://react-hook-form.com/) propose pas mal de fonctionalités que `<Form>` n'expose pas. Lorsque vous souhaitez les utiliser, appelez juste le 'hook' `useForm()` vous-même, en vous assurant de bien passer en argument l'objet retourné (`formMethods`) comme propriété de `<Form>` de façon à ce que la validation et les autres fonctionalités puissent continuer à fonctionner. 
+C'est terminé! [React Hook Form](https://react-hook-form.com/) propose pas mal de fonctionalités que `<Form>` n'expose pas. Lorsque vous souhaitez les utiliser, appelez juste le 'hook' `useForm()` vous-même, en vous assurant de bien passer en argument l'objet retourné (`formMethods`) comme propriété de `<Form>` de façon à ce que la validation et les autres fonctionalités puissent continuer à fonctionner.
 
 > Vous avez peut-être remarqué que la validation onBlur a cessé de fonctionner lorsque vous avez commencé à appeler `userForm()` par vous-même. Ceci s'explique car Redwood invoque `userForm()` et lui passe automatiquement en argument ce que vous avez passé à `<Form>`. Puisque Redwood n'appelle plus automatiquement `useForm()` à votre place, vous devez de faire manuellement:
 >
 > ```javascript
-> const formMethods = useForm({ mode: 'onBlur' })
+> const formMethods = useForm({ mode: "onBlur" });
 > ```
 
 La partie publique du site a bon aspect. Que faire maintenant de la partie administration qui nous permet de créer et éditer les articles? Nous devrions la déplacer dans une partie réservée et la placer derrière un login, de façon à ce des utilisateurs mal intentionnés ne puissent pas créer en chaîne, par exemple, des publicités pour l'achat de médicaments en ligne...


### PR DESCRIPTION


Updated markdown syntax to comply with `remark` parser used in Docusaurus. 

Before: 
```
```javascript{3-8}
```

After: 
```
```javascript {3-8}
```
![image](https://user-images.githubusercontent.com/9841162/102720704-bc8a8400-42aa-11eb-9225-7c52a04c5398.png)
