### PR TITLE
Add redirects from /docs and /docs/tutorial

### DIFF
--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { Redirect } from "@docusaurus/router";
 
-function Home() {
+function Docs() {
 	// Must use relative path to allow dynamic routing in various locales
-	return <Redirect to="./docs/tutorial/welcome-to-redwood" />;
+	return <Redirect to="./tutorial/welcome-to-redwood" />;
 }
 
-export default Home;
+export default Docs;

--- a/src/pages/docs/tutorial/index.js
+++ b/src/pages/docs/tutorial/index.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { Redirect } from "@docusaurus/router";
 
-function Home() {
+function Tutorial() {
 	// Must use relative path to allow dynamic routing in various locales
-	return <Redirect to="./docs/tutorial/welcome-to-redwood" />;
+	return <Redirect to="./welcome-to-redwood" />;
 }
 
-export default Home;
+export default Tutorial;


### PR DESCRIPTION
Adds redirects from `/docs` and `/docs/tutorial` to "Welcome to Redwood" tutorial

Works for both English:
```
yarn start 

/docs           -> /docs/tutorial/welcome-to-redwood
/docs/tutorial  -> /docs/tutorial/welcome-to-redwood
```

and other locales (ex: French):

```
yarn start --locale fr

/fr/docs           -> /fr/docs/tutorial/welcome-to-redwood
/fr/docs/tutorial  -> /fr/docs/tutorial/welcome-to-redwood
```