### PR TITLE
increase contrast for code comments

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -107,7 +107,7 @@ html[data-theme='dark'] blockquote [class^='codeBlockLines'] {
 }
 
 .token.comment {
-  color: #634747 !important;
+  color: #8e8282 !important;
 }
 
 .navbar {


### PR DESCRIPTION
This pull request increases the color contrast for comments in code snippets from 2.2 to 5.05 in order to address https://github.com/redwoodjs/learn.redwoodjs.com/issues/38


This change can be viewed by visiting https://deploy-preview-42--learn-redwood.netlify.app/docs/tutorial/cells/#our-first-cell and inspecting the code comment to see the 5.05 contrast both in light and dark mode.

| Before Changes       (contrast - 2.2)                                                                                                                                                                                                                                                                                                                           | After Changes       (contrast - 5.05)                                                                                                                                                                                                                                                                                                                            |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="831" alt="Screen Shot 2021-01-24 at 7 38 29 PM" src="https://user-images.githubusercontent.com/6998954/105648877-c4c27a00-5e7b-11eb-8549-cd7c8d39f0d8.png"> <img width="834" alt="Screen Shot 2021-01-24 at 7 40 41 PM" src="https://user-images.githubusercontent.com/6998954/105648939-0fdc8d00-5e7c-11eb-8c58-9828f186dd57.png"> | <img width="856" alt="Screen Shot 2021-01-24 at 7 38 23 PM" src="https://user-images.githubusercontent.com/6998954/105648876-c4c27a00-5e7b-11eb-8f12-aa4edd58e481.png"> <img width="860" alt="Screen Shot 2021-01-24 at 7 40 58 PM" src="https://user-images.githubusercontent.com/6998954/105648950-1a972200-5e7c-11eb-8d84-d2337834020a.png"> |
|                                                                                                                                                                                                                                                                                                                                                 |                                                                                                                                                                                                                                                                                                                                                 |