### PR TITLE
Add a plugin to localize youtube players

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const locales = ['en', 'fr'];
 
 const localeConfigs = {
@@ -30,7 +31,7 @@ module.exports = {
       apiKey: process.env.ALGOLIA_API_KEY || 'dev',
       indexName: process.env.ALGOLIA_INDEX_NAME || 'dev',
       contextualSearch: true,
-      searchParameters: {}
+      searchParameters: {},
     },
     navbar: {
       title: 'Learn RedwoodJS',
@@ -126,6 +127,7 @@ module.exports = {
     ],
   ],
   stylesheets: [
-    "https://fonts.googleapis.com/css?family=Open+Sans:400,600,700&display=swap"
+    'https://fonts.googleapis.com/css?family=Open+Sans:400,600,700&display=swap',
   ],
+  plugins: [path.resolve(__dirname, 'plugins', 'youtube-localize-plugin')],
 };

--- a/plugins/youtube-localize-plugin.js
+++ b/plugins/youtube-localize-plugin.js
@@ -1,0 +1,19 @@
+module.exports = function (_context, _options) {
+  return {
+    name: 'youtube-localize-plugin',
+    injectHtmlTags() {
+      return {
+        preBodyTags: [
+          {
+            tagName: 'script',
+            attributes: {
+              charset: 'utf-8',
+              src:
+                'https://clairefro.github.io/docusaurus-youtube-localize-plugin/index.js',
+            },
+          },
+        ],
+      };
+    },
+  };
+};


### PR DESCRIPTION
Adds a custom plugin that searches all `<iframe>`s for embedded youtube videos, and modifies their `src` url params to make the video player controls and subtitles (if published) appear in the language defined in a page's `<html lang="<lang>">`



While the player controls always translate, subtitles will only appear if officially published by the Youtube Video owner. 

Currently, only the first video in the "Welcome to Redwood Page" has officially published auto-generated subtitles. I'm sure the French is a bit funny (Redwood has become _séquoia_... lol), but it's better than nothin!

![image](https://user-images.githubusercontent.com/9841162/105662727-51be0100-5e85-11eb-9c40-c9caacece710.png)

_*Note: this is a hacky temporary solution. Since I was unable to get local plugin scripts to resolve in production, I ended up hosting the script from github [here](https://github.com/clairefro/docusaurus-youtube-localize-plugin) (it works :shrug:). I've asked docusaurus people for advice._