### PR TITLE
Fix Docusaurus url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,7 +18,7 @@ module.exports = {
   title: 'Learn RedwoodJS',
   tagline:
     'Built on React, GraphQL, and Prisma, Redwood works with the components and development workflow you love, but with simple conventions and helpers to make your experience even better.',
-  url: 'https://github.com/redwoodjs/learn.redwoodjs.com',
+  url: 'https://learn-redwood.netlify.app',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
This should be the URL of the site, not URL of the git repo

https://v2.docusaurus.io/docs/next/docusaurus.config.js/#url

This should fix the bad sitemap containing github.com:
- https://learn-redwood.netlify.app/sitemap.xml
- https://learn-redwood.netlify.app/fr/sitemap.xml
 
That prevents Algolia Docsearch to work on `/fr/` urls