### PR TITLE
Fix/change french edit links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,7 +111,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/redwoodjs/learn.redwoodjs.com/',
+          editUrl: 'https://github.com/redwoodjs/learn.redwoodjs.com',
         },
         blog: {
           showReadingTime: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,10 +111,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl:
-           
-           
-            'https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/',
+          editUrl: 'https://github.com/redwoodjs/learn.redwoodjs.com/',
         },
         blog: {
           showReadingTime: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,7 @@ module.exports = {
       apiKey: process.env.ALGOLIA_API_KEY || 'dev',
       indexName: process.env.ALGOLIA_INDEX_NAME || 'dev',
       contextualSearch: true,
-      searchParameters: {}
+      searchParameters: {},
     },
     navbar: {
       title: 'Learn RedwoodJS',
@@ -111,7 +111,10 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/redwoodjs/learn.redwoodjs.com',
+          editUrl:
+           
+           
+            'https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/',
         },
         blog: {
           showReadingTime: true,
@@ -126,6 +129,6 @@ module.exports = {
     ],
   ],
   stylesheets: [
-    "https://fonts.googleapis.com/css?family=Open+Sans:400,600,700&display=swap"
+    'https://fonts.googleapis.com/css?family=Open+Sans:400,600,700&display=swap',
   ],
 };

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/a-second-page-and-a-link.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/a-second-page-and-a-link.md
@@ -2,6 +2,7 @@
 id: a-second-page-and-a-link
 title: "Une Seconde Page et un Lien"
 sidebar_label: "Une Seconde Page et un Lien"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Ajoutons donc une page "About" à notre blog de manière à ce que personne n'ignore qui se trouve derrière cette application exceptionnelle. Nous allons créer une nouvelle page en utilisant `redwood`:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/administration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/administration.md
@@ -2,6 +2,7 @@
 id: administration
 title: "Administration"
 sidebar_label: "Administration"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Il semble raisonable de faire en sorte que les écrans d'administration soient regroupés sous un chemin `/admin`. Mettons à jour les routes de manière à ce que les quatre routes commençant par `/posts` commencent désormais paar `/admin/posts`:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/authentication.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/authentication.md
@@ -2,6 +2,7 @@
 id: authentication
 title: "Authentification"
 sidebar_label: "Authentification"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 "Authentification" est un mot-valise pour tout ce qui se rapporte au fait de s'assurer que l'utilisateur, souvent identifié à l'aide d'un couple email/mot de passe, est autorisé à accéder à quelque chose. L'authentification peut être parfois [délicate à mettre en oeuvre](https://www.rdegges.com/2017/authentication-still-sucks/) techniquement et vous causer de sérieux maux de tête.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/cells.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/cells.md
@@ -2,6 +2,7 @@
 id: cells
 title: "Cells"
 sidebar_label: "Cells"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Ces fonctionnalités sont courantes dans la plupart des applications web. Nous voulions voir s'il était possible de faciliter la vie aux développeurs. Nous pensons être arrivé à réaliser quelque chose d'utile. Nous appelons ça les _Cells_ (ou _cellules_ en français). Les Cells proposent une approche simple et déclarative pour récupérer des données au sein de vos composants. ([Lisez la documentation complète sur Cells](https://redwoodjs.com/docs/cells).)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/deployment.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/deployment.md
@@ -2,6 +2,7 @@
 id: deployment
 title: "Déploiement"
 sidebar_label: "Déploiement"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 La partie 4 de ce didacticiel en vidéo se trouve ici:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/everyones-favorite-thing-to-build-forms.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/everyones-favorite-thing-to-build-forms.md
@@ -2,6 +2,7 @@
 id: everyones-favorite-thing-to-build-forms
 title: "Votre partie préférée: Les Formulaires"
 sidebar_label: "Votre partie préférée: Les Formulaires"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Attendez, ne fermez pas votre navigateur ! Vous deviez bien vous douter que ça allait venir, non? Et vous vous êtes probablement rendu compte maintenant que nous n'aurions même pas cette section dans le tutoriel à moins que Redwood n'ait trouvé un moyen astucieux de faire les choses. En fait, Redwood pourrait même vous faire _aimer_ les formulaires. Bon, aimer est peut-être un peu fort. Disons _apprécier_ travailler avec les formulaires, ou à tout le moins les _tolérer_?

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/getting-dynamic.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/getting-dynamic.md
@@ -2,6 +2,7 @@
 id: getting-dynamic
 title: "Devenir Dynamique"
 sidebar_label: "Devenir Dynamique"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 La seconde partie du didacticiel est disponible en video ici:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/installation-starting-development.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/installation-starting-development.md
@@ -2,6 +2,7 @@
 id: installation-starting-development
 title: "Installation & Démarrage du développement"
 sidebar_label: "Installation & Démarrage du développement"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Nous utiliserons yarn ([yarn](https://yarnpkg.com/en/docs/install) est un pré-requis) pour créer la structure de base pour notre application :

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/layouts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/layouts.md
@@ -2,6 +2,7 @@
 id: layouts
 title: "Layouts"
 sidebar_label: "Layouts"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Une façon de résoudre la duplication du `<header>` aurait pu être de créer un composant `<Header>` et l'inclure à la fois dans `HomePage` et `AboutPage`. Cela fonctionne, mais y a-t-il une meilleure solution? Dans l'idéal, votre code ne devrait comporter qu'une seule et unique balise `<header>`.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/our-first-page.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/our-first-page.md
@@ -2,6 +2,7 @@
 id: our-first-page
 title: "Notre Première Page"
 sidebar_label: "Notre Première Page"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Donnons à nos utilisateurs quelque chose de plus à contempler que la page d'accueil de Redwood. Utilisons la commande `redwood` pour créer une première page :

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/prerequisites.md
@@ -2,6 +2,7 @@
 id: prerequisites
 title: "Prérequis"
 sidebar_label: "Prérequis"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Ce didacticiel suppose que vous soyez déjà familier avec quelques concepts fondamentaux :

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/redwood-file-structure.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/redwood-file-structure.md
@@ -2,6 +2,7 @@
 id: redwood-file-structure
 title: "Structure d'une application Redwood"
 sidebar_label: "Structure d'une application Redwood"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Examinons maintenant les fichiers et répertoires qui ont été créés pour nous (laissons de côté les fichiers de configuration sur lesquels nous reviendrons plus tard)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/routing-params.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/routing-params.md
@@ -2,6 +2,7 @@
 id: routing-params
 title: "Paramètres de Routes"
 sidebar_label: "Paramètres de Routes"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Maintenant que notre page d'accueil liste l'ensemble des articles de notre blog, il est temps de créer une page présentant le détail d'un article. Commençons par générer une page et sa route associée:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/saving-data.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/saving-data.md
@@ -2,6 +2,7 @@
 id: saving-data
 title: "Enregistrer les Données"
 sidebar_label: "Enregistrer les Données"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Ajoutons une nouvelle table à notre base de données. Ouvrez `api/prisma/schema.prisma` et ajoutez un nouveau modèle "Contact" à la suite du premier modèle "Post":

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/side-quest-how-redwood-works-with-data.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/side-quest-how-redwood-works-with-data.md
@@ -2,6 +2,7 @@
 id: side-quest-how-redwood-works-with-data
 title: "Quête secondaire: Fonctionnement de Redwood avec les Données"
 sidebar_label: "Quête secondaire: Fonctionnement de Redwood avec les Données"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Redwood apprécie GraphQL. Nous pensons qu'il s'agit de l'API pour l'avenir. Notre implémentation de GraphQL is construite avec [Apollo](https://www.apollographql.com/). Voici comment une requête GraphQL classique fonctionne dans votre application:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/welcome-to-redwood.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/welcome-to-redwood.md
@@ -2,6 +2,7 @@
 id: welcome-to-redwood
 title: "Bienvenue chez Redwood"
 sidebar_label: "Bienvenue chez Redwood"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Bienvenue chez Redwood! Si vous ne l’avez pas encore fait, prenez le temps de lire [Redwood README](https://github.com/redwoodjs/redwood/blob/main/README.md) pour en savoir un peu plus sur les origines de Redwood et les problèmes qu'il entend résoudre. Redwood assemble plusieurs technologies de façon inédite et qui correspond à ce que nous pensons être le futur des applications web avec base de données.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/wrapping-up.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/wrapping-up.md
@@ -2,6 +2,7 @@
 id: wrapping-up
 title: "Conclusion"
 sidebar_label: "Conclusion"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Vous l'avez fait! Si vous avez vraiment parcouru tout le tutoriel: félicitations! Si vous venez de passer à cette page pour essayer d'obtenir des félicitations gratuites: tss, tss...


### PR DESCRIPTION
Changes "Edit this page" url for **French** pages only to the Translation README.

The translation README explains that changes to localized content must be made via Crowdin, with instructions on how to get involved 

https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md