### PR TITLE
Update link at docusaurus.config.js > prests > docs > editUrl

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,7 +111,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/redwoodjs/learn.redwoodjs.com',
+          editUrl: 'https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
Hi

This PR to edit this [link](https://github.com/redwoodjs/learn.redwoodjs.com) to [this](https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/) at `docusaurus.config.js > prests > docs > editUrl`

The changes in branch `feat/editpagelink`

I hope this works fine

If it need another update I hope anyone help me

Thanks