### PR TITLE
Add custom edit url to french pages

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/a-second-page-and-a-link.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/a-second-page-and-a-link.md
@@ -2,6 +2,7 @@
 id: a-second-page-and-a-link
 title: "Une Seconde Page et un Lien"
 sidebar_label: "Une Seconde Page et un Lien"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Ajoutons donc une page "About" à notre blog de manière à ce que personne n'ignore qui se trouve derrière cette application exceptionnelle. Nous allons créer une nouvelle page en utilisant `redwood`:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/administration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/administration.md
@@ -2,6 +2,7 @@
 id: administration
 title: "Administration"
 sidebar_label: "Administration"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Il semble raisonable de faire en sorte que les écrans d'administration soient regroupés sous un chemin `/admin`. Mettons à jour les routes de manière à ce que les quatre routes commençant par `/posts` commencent désormais paar `/admin/posts`:

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/authentication.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/authentication.md
@@ -2,6 +2,7 @@
 id: authentication
 title: "Authentification"
 sidebar_label: "Authentification"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 "Authentification" est un mot-valise pour tout ce qui se rapporte au fait de s'assurer que l'utilisateur, souvent identifié à l'aide d'un couple email/mot de passe, est autorisé à accéder à quelque chose. L'authentification peut être parfois [délicate à mettre en oeuvre](https://www.rdegges.com/2017/authentication-still-sucks/) techniquement et vous causer de sérieux maux de tête.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/installation-starting-development.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/installation-starting-development.md
@@ -2,6 +2,7 @@
 id: installation-starting-development
 title: "Installation & Démarrage du développement"
 sidebar_label: "Installation & Démarrage du développement"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Nous utiliserons yarn ([yarn](https://yarnpkg.com/en/docs/install) est un pré-requis) pour créer la structure de base pour notre application :

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/layouts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/layouts.md
@@ -2,6 +2,7 @@
 id: layouts
 title: "Layouts"
 sidebar_label: "Layouts"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Une façon de résoudre la duplication du `<header>` aurait pu être de créer un composant `<Header>` et l'inclure à la fois dans `HomePage` et `AboutPage`. Cela fonctionne, mais y a-t-il une meilleure solution? Dans l'idéal, votre code ne devrait comporter qu'une seule et unique balise `<header>`.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/redwood-file-structure.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/redwood-file-structure.md
@@ -2,6 +2,7 @@
 id: redwood-file-structure
 title: "Structure d'une application Redwood"
 sidebar_label: "Structure d'une application Redwood"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Examinons maintenant les fichiers et répertoires qui ont été créés pour nous (laissons de côté les fichiers de configuration sur lesquels nous reviendrons plus tard)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/saving-data.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/tutorial/saving-data.md
@@ -2,6 +2,7 @@
 id: saving-data
 title: "Enregistrer les Données"
 sidebar_label: "Enregistrer les Données"
+custom_edit_url: https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md
 ---
 
 Ajoutons une nouvelle table à notre base de données. Ouvrez `api/prisma/schema.prisma` et ajoutez un nouveau modèle "Contact" à la suite du premier modèle "Post":


### PR DESCRIPTION
Adds a custom edit url back to newly translated French pages

Note: this is a temporary fix - as right now each Crowdin PR deletes the custom edit url because it doesn't exist in the source. I'm in contact with docusaurus to find a better way