### PR TITLE
Add announcement banner call for translators

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,6 +39,15 @@ module.exports = {
   organizationName: 'redwoodjs', // Usually your GitHub org/user name.
   projectName: 'learn.redwoodjs.com', // Usually your repo name.,
   themeConfig: {
+    announcementBar: {
+      id: 'support_us', // Any value that will identify this message.
+      content:
+        'We are looking for help translating this site into <b>French</b> and <b>Spanish</b>! <a target="_blank" rel="noopener noreferrer" href="https://github.com/redwoodjs/learn.redwoodjs.com/blob/main/README_TRANSLATION_GUIDE.md">See our guide</a>',
+      // NOTE: setting colors in custom.css instead as text color below was not rendering
+      // backgroundColor: '#120401',
+      // textColor: '##ffffff',
+      isCloseable: false, // Defaults to `true`.
+    },
     algolia: {
       apiKey: process.env.ALGOLIA_API_KEY || 'dev',
       indexName: process.env.ALGOLIA_INDEX_NAME || 'dev',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -208,3 +208,16 @@ html[data-theme='dark'] .footer__copyright {
   width: 100%;
   height: 100%;
 }
+
+/* Announcement bar */
+
+[class^='announcementBarContent'] {
+  color: #fff;
+  background-color: var(--ifm-color-primary);
+}
+html[data-theme='dark'] [class^='announcementBarContent'] {
+  color: #fff;
+}
+html[data-theme='dark'] [class^='announcementBarContent'] a {
+  color: #fff;
+}


### PR DESCRIPTION
This banner appears at the top of all pages, calling for help with French and Spanish translation.

It disappears on scroll.

dark mode
![image](https://user-images.githubusercontent.com/9841162/110402026-84841900-802f-11eb-84ba-9528de94aef5.png)

light mode
![image](https://user-images.githubusercontent.com/9841162/110402046-8a79fa00-802f-11eb-8a2c-4f204f55d06d.png)

on scroll (disappears)
![image](https://user-images.githubusercontent.com/9841162/110402070-92399e80-802f-11eb-8a0d-d9d011a6de9f.png)

