### PR TITLE
Add icons for external linking, add Cookbooks link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,12 +64,12 @@ module.exports = {
         {
           to: 'https://redwoodjs.com/docs/introduction',
           activeBasePath: 'docs',
-          label: 'Docs',
+          label: 'Docs ⇗',
           position: 'left',
         },
         {
-          to: 'https://redwoodjs.com/',
-          label: 'Redwoodjs.com',
+          to: 'https://redwoodjs.com/cookbook/custom-function',
+          label: 'Cookbooks ⇗',
           position: 'left',
         },
         { type: 'localeDropdown', position: 'right' },


### PR DESCRIPTION
Makes it clear that Docs and Cookbook link to .com
![image](https://user-images.githubusercontent.com/9841162/110531269-37a44f00-80d0-11eb-9734-65cb8aab4dfc.png)

![image](https://user-images.githubusercontent.com/9841162/110531334-47239800-80d0-11eb-9906-188312f02d5e.png)
