### PR TITLE
Switch to using `<Set>`

### DIFF
--- a/docs/tutorial/authentication.md
+++ b/docs/tutorial/authentication.md
@@ -158,18 +158,21 @@ Now try creating, editing or deleting a post from our admin pages. Nothing happe
 
 Now we'll restrict access to the admin pages completely unless you're logged in. The first step will be to denote which routes will require that you be logged in. Enter the `<Private>` tag:
 
-```javascript {3,12,16}
+```javascript {3,15,20}
 // web/src/Routes.js
 
-import { Router, Route, Private } from '@redwoodjs/router'
+import { Router, Route, Set, Private } from '@redwoodjs/router'
+import BlogPostLayout from 'src/layouts/BlogPostLayout'
 
 const Routes = () => {
   return (
     <Router>
-      <Route path="/contact" page={ContactPage} name="contact" />
-      <Route path="/about" page={AboutPage} name="about" />
-      <Route path="/" page={HomePage} name="home" />
-      <Route path="/blog-post/{id:Int}" page={BlogPostPage} name="blogPost" />
+      <Set wrap={BlogPostLayout}>
+        <Route path="/blog-post/{id:Int}" page={BlogPostPage} name="blogPost" />
+        <Route path="/contact" page={ContactPage} name="contact" />
+        <Route path="/about" page={AboutPage} name="about" />
+        <Route path="/" page={HomePage} name="home" />
+      </Set>
       <Private unauthenticated="home">
         <Route path="/admin/posts/new" page={NewPostPage} name="newPost" />
         <Route path="/admin/posts/{id:Int}/edit" page={EditPostPage} name="editPost" />

--- a/docs/tutorial/cells.md
+++ b/docs/tutorial/cells.md
@@ -146,17 +146,14 @@ export const Success = ({ posts }) => {
 
 Let's plug this cell into our `HomePage` and see what happens:
 
-```javascript {4,9}
+```javascript {3,7}
 // web/src/pages/HomePage/HomePage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
 import BlogPostsCell from 'src/components/BlogPostsCell'
 
 const HomePage = () => {
   return (
-    <BlogLayout>
-      <BlogPostsCell />
-    </BlogLayout>
+    <BlogPostsCell />
   )
 }
 

--- a/docs/tutorial/everyones-favorite-thing-to-build-forms.md
+++ b/docs/tutorial/everyones-favorite-thing-to-build-forms.md
@@ -57,18 +57,19 @@ const BlogLayout = ({ children }) => {
 export default BlogLayout
 ```
 
-And then use the `BlogLayout` in the `ContactPage`:
+And then use the `BlogLayout` for the `ContactPage` by making sure its wrapped by the same `<Set>` as the other pages in the routes file:
 
-```javascript {3,6}
-// web/src/pages/ContactPage/ContactPage.js
+```javascript {5}
+// web/src/Routes.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
-
-const ContactPage = () => {
-  return <BlogLayout></BlogLayout>
-}
-
-export default ContactPage
+<Router>
+  <Set wrap={BlogLayout}>
+    <Route path="/contact" page={ContactPage} name="contact" />
+    <Route path="/about" page={AboutPage} name="about" />
+    <Route path="/" page={HomePage} name="home" />
+  </Set>
+  <Route notfound page={NotFoundPage} />
+</Router>
 ```
 
 Double check that everything looks good and then let's get to the good stuff.
@@ -104,17 +105,14 @@ input.error, textarea.error {
 
 For now we won't be talking to the database in our Contact form so we won't create a cell. Let's create the form right on the page. Redwood forms start with the...wait for it...`<Form>` tag:
 
-```javascript {3,9}
+```javascript {3,7}
 // web/src/pages/ContactPage/ContactPage.js
 
 import { Form } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 const ContactPage = () => {
   return (
-    <BlogLayout>
-      <Form></Form>
-    </BlogLayout>
+    <Form></Form>
   )
 }
 
@@ -123,19 +121,16 @@ export default ContactPage
 
 Well that was anticlimactic. You can't even see it in the browser. Let's add a form field so we can at least see something. Redwood ships with several inputs and a plain text input box is `<TextField>`. We'll also give the field a `name` attribute so that once there are multiple inputs on this page we'll know which contains which data:
 
-```javascript {3,10}
+```javascript {3,8}
 // web/src/pages/ContactPage/ContactPage.js
 
 import { Form, TextField } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 const ContactPage = () => {
   return (
-    <BlogLayout>
-      <Form>
-        <TextField name="input" />
-      </Form>
-    </BlogLayout>
+    <Form>
+      <TextField name="input" />
+    </Form>
   )
 }
 
@@ -146,20 +141,17 @@ export default ContactPage
 
 Something is showing! Still, pretty boring. How about adding a submit button?
 
-```javascript {3,11}
+```javascript {3,9}
 // web/src/pages/ContactPage/ContactPage.js
 
 import { Form, TextField, Submit } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 const ContactPage = () => {
   return (
-    <BlogLayout>
-      <Form>
-        <TextField name="input" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
+    <Form>
+      <TextField name="input" />
+      <Submit>Save</Submit>
+    </Form>
   )
 }
 
@@ -174,7 +166,7 @@ We have what might actually be considered a real, bonafide form here. Try typing
 
 Similar to a plain HTML form we'll give `<Form>` an `onSubmit` handler. That handler will be called with a single argument—an object containing all of the submitted form fields:
 
-```javascript {4-6,10}
+```javascript {4-6,9}
 // web/src/pages/ContactPage/ContactPage.js
 
 const ContactPage = () => {
@@ -183,12 +175,10 @@ const ContactPage = () => {
   }
 
   return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <TextField name="input" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
+    <Form onSubmit={onSubmit}>
+      <TextField name="input" />
+      <Submit>Save</Submit>
+    </Form>
   )
 }
 ```
@@ -199,11 +189,10 @@ Now try filling in some data and submitting:
 
 Great! Let's turn this into a more useful form by adding a couple fields. We'll rename the existing one to "name" and add "email" and "message":
 
-```javascript {3,14-16}
+```javascript {3,12-14}
 // web/src/pages/ContactPage/ContactPage.js
 
 import { Form, TextField, TextAreaField, Submit } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 const ContactPage = () => {
   const onSubmit = (data) => {
@@ -211,14 +200,12 @@ const ContactPage = () => {
   }
 
   return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <TextField name="name" />
-        <TextField name="email" />
-        <TextAreaField name="message" />
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
+    <Form onSubmit={onSubmit}>
+      <TextField name="name" />
+      <TextField name="email" />
+      <TextAreaField name="message" />
+      <Submit>Save</Submit>
+    </Form>
   )
 }
 
@@ -231,24 +218,22 @@ See the new `<TextAreaField>` component here which generates an HTML `<textarea>
 
 Let's add some labels:
 
-```javascript {6,9,12}
+```javascript {5,8,11}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" />
+  <Form onSubmit={onSubmit}>
+    <label htmlFor="name">Name</label>
+    <TextField name="name" />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" />
+    <label htmlFor="email">Email</label>
+    <TextField name="email" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" />
+    <label htmlFor="message">Message</label>
+    <TextAreaField name="message" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
+    <Submit>Save</Submit>
+  </Form>
 )
 ```
 
@@ -262,24 +247,22 @@ Try filling out the form and submitting and you should get a console message wit
 
 All three of these fields should be required in order for someone to send a message to us. Let's enforce that with the standard HTML `required` attribute:
 
-```javascript {7,10,13}
+```javascript {6,9,12}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" required />
+  <Form onSubmit={onSubmit}>
+    <label htmlFor="name">Name</label>
+    <TextField name="name" required />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" required />
+    <label htmlFor="email">Email</label>
+    <TextField name="email" required />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" required />
+    <label htmlFor="message">Message</label>
+    <TextAreaField name="message" required />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
+    <Submit>Save</Submit>
+  </Form>
 )
 ```
 
@@ -289,24 +272,22 @@ Now when trying to submit there'll be message from the browser noting that a fie
 
 Yes! Let's update that `required` call to instead be an object we pass to a custom attribute on Redwood form helpers called `validation`:
 
-```javascript {7,10,13}
+```javascript {6,9,12}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" validation={{ required: true }} />
+  <Form onSubmit={onSubmit}>
+    <label htmlFor="name">Name</label>
+    <TextField name="name" validation={{ required: true }} />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" validation={{ required: true }} />
+    <label htmlFor="email">Email</label>
+    <TextField name="email" validation={{ required: true }} />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" validation={{ required: true }} />
+    <label htmlFor="message">Message</label>
+    <TextAreaField name="message" validation={{ required: true }} />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
+    <Submit>Save</Submit>
+  </Form>
 )
 ```
 
@@ -316,7 +297,7 @@ And now when we submit the form with blank fields...the Name field gets focus. B
 
 Introducing `<FieldError>` (don't forget to include it in the `import` statement at the top):
 
-```javascript {8,22,26,30}
+```javascript {8,20,24,28}
 // web/src/pages/ContactPage/ContactPage.js
 
 import {
@@ -326,7 +307,6 @@ import {
   Submit,
   FieldError,
 } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 const ContactPage = () => {
   const onSubmit = (data) => {
@@ -334,23 +314,21 @@ const ContactPage = () => {
   }
 
   return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <label htmlFor="name">Name</label>
-        <TextField name="name" validation={{ required: true }} />
-        <FieldError name="name" />
+    <Form onSubmit={onSubmit}>
+      <label htmlFor="name">Name</label>
+      <TextField name="name" validation={{ required: true }} />
+      <FieldError name="name" />
 
-        <label htmlFor="email">Email</label>
-        <TextField name="email" validation={{ required: true }} />
-        <FieldError name="email" />
+      <label htmlFor="email">Email</label>
+      <TextField name="email" validation={{ required: true }} />
+      <FieldError name="email" />
 
-        <label htmlFor="message">Message</label>
-        <TextAreaField name="message" validation={{ required: true }} />
-        <FieldError name="message" />
+      <label htmlFor="message">Message</label>
+      <TextAreaField name="message" validation={{ required: true }} />
+      <FieldError name="message" />
 
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
+      <Submit>Save</Submit>
+    </Form>
   )
 }
 
@@ -363,27 +341,25 @@ Note that the `name` attribute matches the `name` of the input field above it. T
 
 But this is just the beginning. Let's make sure folks realize this is an error message. Remember the `.error` class we defined in `index.css`? Check out the `className` attribute on `<FieldError>`:
 
-```javascript {8,12,16}
+```javascript {7,11,15}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField name="name" validation={{ required: true }} />
-      <FieldError name="name" className="error" />
+  <Form onSubmit={onSubmit}>
+    <label htmlFor="name">Name</label>
+    <TextField name="name" validation={{ required: true }} />
+    <FieldError name="name" className="error" />
 
-      <label htmlFor="email">Email</label>
-      <TextField name="email" validation={{ required: true }} />
-      <FieldError name="email" className="error" />
+    <label htmlFor="email">Email</label>
+    <TextField name="email" validation={{ required: true }} />
+    <FieldError name="email" className="error" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField name="message" validation={{ required: true }} />
-      <FieldError name="message" className="error" />
+    <label htmlFor="message">Message</label>
+    <TextAreaField name="message" validation={{ required: true }} />
+    <FieldError name="message" className="error" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
+    <Submit>Save</Submit>
+  </Form>
 )
 ```
 
@@ -391,39 +367,37 @@ return (
 
 You know what would be nice? If the input itself somehow displayed the fact that there was an error. Check out the `errorClassName` attributes on the inputs:
 
-```javascript {10,18,26}
+```javascript {9,17,25}
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
-    <Form onSubmit={onSubmit}>
-      <label htmlFor="name">Name</label>
-      <TextField
-        name="name"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="name" className="error" />
+  <Form onSubmit={onSubmit}>
+    <label htmlFor="name">Name</label>
+    <TextField
+      name="name"
+      validation={{ required: true }}
+      errorClassName="error"
+    />
+    <FieldError name="name" className="error" />
 
-      <label htmlFor="email">Email</label>
-      <TextField
-        name="email"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="email" className="error" />
+    <label htmlFor="email">Email</label>
+    <TextField
+      name="email"
+      validation={{ required: true }}
+      errorClassName="error"
+    />
+    <FieldError name="email" className="error" />
 
-      <label htmlFor="message">Message</label>
-      <TextAreaField
-        name="message"
-        validation={{ required: true }}
-        errorClassName="error"
-      />
-      <FieldError name="message" className="error" />
+    <label htmlFor="message">Message</label>
+    <TextAreaField
+      name="message"
+      validation={{ required: true }}
+      errorClassName="error"
+    />
+    <FieldError name="message" className="error" />
 
-      <Submit>Save</Submit>
-    </Form>
-  </BlogLayout>
+    <Submit>Save</Submit>
+  </Form>
 )
 ```
 
@@ -431,7 +405,7 @@ return (
 
 Oooo, what if the _label_ could change as well? It can, but we'll need Redwood's custom `<Label>` component for that. Note that the `htmlFor` attribute of `<label>` becomes the `name` prop on `<Label>`, just like with the other Redwood form components. And don't forget the import:
 
-```javascript {9,21-23,31-33,41-43}
+```javascript {9,19-21,29-31,39-41}
 // web/src/pages/ContactPage/ContactPage.js
 
 import {
@@ -442,7 +416,6 @@ import {
   FieldError,
   Label,
 } from '@redwoodjs/forms'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 const ContactPage = () => {
   const onSubmit = (data) => {
@@ -450,41 +423,39 @@ const ContactPage = () => {
   }
 
   return (
-    <BlogLayout>
-      <Form onSubmit={onSubmit}>
-        <Label name="name" errorClassName="error">
-          Name
-        </Label>
-        <TextField
-          name="name"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="name" className="error" />
+    <Form onSubmit={onSubmit}>
+      <Label name="name" errorClassName="error">
+        Name
+      </Label>
+      <TextField
+        name="name"
+        validation={{ required: true }}
+        errorClassName="error"
+      />
+      <FieldError name="name" className="error" />
 
-        <Label name="email" errorClassName="error">
-          Email
-        </Label>
-        <TextField
-          name="email"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="email" className="error" />
+      <Label name="email" errorClassName="error">
+        Email
+      </Label>
+      <TextField
+        name="email"
+        validation={{ required: true }}
+        errorClassName="error"
+      />
+      <FieldError name="email" className="error" />
 
-        <Label name="message" errorClassName="error">
-          Message
-        </Label>
-        <TextAreaField
-          name="message"
-          validation={{ required: true }}
-          errorClassName="error"
-        />
-        <FieldError name="message" className="error" />
+      <Label name="message" errorClassName="error">
+        Message
+      </Label>
+      <TextAreaField
+        name="message"
+        validation={{ required: true }}
+        errorClassName="error"
+      />
+      <FieldError name="message" className="error" />
 
-        <Submit>Save</Submit>
-      </Form>
-    </BlogLayout>
+      <Submit>Save</Submit>
+    </Form>
   )
 }
 

--- a/docs/tutorial/layouts.md
+++ b/docs/tutorial/layouts.md
@@ -48,7 +48,7 @@ const BlogLayout = ({ children }) => {
 export default BlogLayout
 ```
 
-`children` is where the magic will happen. Any page content given to the layout will be rendered here. So in our router, we'll wrap `HomePage` and `AboutPage` with the `BlogLayout`, using a `<Set>`, and now they're back to focusing on the content they care about (we can remove the import for `Link` and `routes` from `HomePage` since those are in the Layout instead):
+`children` is where the magic will happen. Any page content given to the layout will be rendered here. In our routes, we'll wrap `HomePage` and `AboutPage` with the `BlogLayout`, using a `<Set>`, and now they're back to focusing on the content they care about (we can remove the import for `Link` and `routes` from `HomePage` since those are in the Layout instead):
 
 ```javascript {3,5,10-13}
 // web/src/Routes.js

--- a/docs/tutorial/layouts.md
+++ b/docs/tutorial/layouts.md
@@ -48,39 +48,23 @@ const BlogLayout = ({ children }) => {
 export default BlogLayout
 ```
 
-`children` is where the magic will happen. Any page content given to the layout will be rendered here. Back to `HomePage` and `AboutPage`, we add a `<BlogLayout>` wrapper and now they're back to focusing on the content they care about (we can remove the import for `Link` and `routes` from `HomePage` since those are in the Layout instead):
+`children` is where the magic will happen. Any page content given to the layout will be rendered here. So in our router, we'll wrap `HomePage` and `AboutPage` with the `BlogLayout`, using a `<Set>`, and now they're back to focusing on the content they care about (we can remove the import for `Link` and `routes` from `HomePage` since those are in the Layout instead):
 
-```javascript {3,6}
-// web/src/pages/HomePage/HomePage.js
+```javascript {3,5,10-13}
+// web/src/Routes.js
 
+import { Router, Route, Set } from '@redwoodjs/router'
 import BlogLayout from 'src/layouts/BlogLayout'
 
-const HomePage = () => {
-  return <BlogLayout>Home</BlogLayout>
-}
+// ...
 
-export default HomePage
-```
-
-```javascript {4,8-14}
-// web/src/pages/AboutPage/AboutPage.js
-
-import { Link, routes } from '@redwoodjs/router'
-import BlogLayout from 'src/layouts/BlogLayout'
-
-const AboutPage = () => {
-  return (
-    <BlogLayout>
-      <p>
-        This site was created to demonstrate my mastery of Redwood: Look on my
-        works, ye mighty, and despair!
-      </p>
-      <Link to={routes.home()}>Return home</Link>
-    </BlogLayout>
-  )
-}
-
-export default AboutPage
+    <Router>
+      <Set wrap={BlogLayout}>
+        <Route path="/about" page={AboutPage} name="about" />
+        <Route path="/" page={HomePage} name="home" />
+      </Set>
+      <Route notfound page={NotFoundPage} />
+    </Router>
 ```
 
 > **The `src` alias**
@@ -136,19 +120,14 @@ And then we can remove the extra "Return to Home" link (and Link/routes import) 
 ```javascript
 // web/src/pages/AboutPage/AboutPage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
-
 const AboutPage = () => {
   return (
-    <BlogLayout>
-      <p>
-        This site was created to demonstrate my mastery of Redwood: Look on my
-        works, ye mighty, and despair!
-      </p>
-    </BlogLayout>
+    <p>
+      This site was created to demonstrate my mastery of Redwood: Look on my
+      works, ye mighty, and despair!
+    </p>
   )
 }
 
 export default AboutPage
 ```
-

--- a/docs/tutorial/layouts.md
+++ b/docs/tutorial/layouts.md
@@ -48,16 +48,16 @@ const BlogLayout = ({ children }) => {
 export default BlogLayout
 ```
 
-`children` is where the magic will happen. Any page content given to the layout will be rendered here. In our routes, we'll wrap `HomePage` and `AboutPage` with the `BlogLayout`, using a `<Set>`, and now they're back to focusing on the content they care about (we can remove the import for `Link` and `routes` from `HomePage` since those are in the Layout instead):
+`children` is where the magic will happen. Any page content given to the layout will be rendered here. And now the pages are back to focusing on the content they care about (we can remove the import for `Link` and `routes` from `HomePage` since those are in the Layout instead). To actually render our layout we'll need to make a change to our routes files. We'll wrap `HomePage` and `AboutPage` with the `BlogLayout`, using a `<Set>`:
 
-```javascript {3,5,10-13}
+```javascript {3,4,9-12}
 // web/src/Routes.js
 
 import { Router, Route, Set } from '@redwoodjs/router'
 import BlogLayout from 'src/layouts/BlogLayout'
 
-// ...
-
+const Routes = () => {
+  return (
     <Router>
       <Set wrap={BlogLayout}>
         <Route path="/about" page={AboutPage} name="about" />
@@ -65,6 +65,10 @@ import BlogLayout from 'src/layouts/BlogLayout'
       </Set>
       <Route notfound page={NotFoundPage} />
     </Router>
+  )
+}
+
+export default Routes
 ```
 
 > **The `src` alias**

--- a/docs/tutorial/routing-params.md
+++ b/docs/tutorial/routing-params.md
@@ -42,7 +42,21 @@ If you click the link on the title of the blog post you should see the boilerpla
 <Route path="/blog-post/{id}" page={BlogPostPage} name="blogPost" />
 ```
 
-Notice the `{id}`. Redwood calls these _route parameters_. They say "whatever value is in this position in the path, let me reference it by the name inside the curly braces."
+Notice the `{id}`. Redwood calls these _route parameters_. They say "whatever value is in this position in the path, let me reference it by the name inside the curly braces". And while we're in the routes file, lets move the route inside the `Set` with the `BlogPostLayout`.
+
+```javascript {5}
+// web/src/Routes.js
+
+<Router>
+  <Set wrap={BlogLayout}>
+    <Route path="/blog-post/{id}" page={BlogPostPage} name="blogPost" />
+    <Route path="/contact" page={ContactPage} name="contact" />
+    <Route path="/about" page={AboutPage} name="about" />
+    <Route path="/" page={HomePage} name="home" />
+  </Set>
+  <Route notfound page={NotFoundPage} />
+</Router>
+```
 
 Cool, cool, cool. Now we need to construct a link that has the ID of a post in it:
 
@@ -60,19 +74,16 @@ Ok, so the ID is in the URL. What do we need next in order to display a specific
 
     yarn rw g cell BlogPost
 
-And then we'll use that cell in `BlogPostPage` (and while we're at it let's surround the page with the `BlogLayout`):
+And then we'll use that cell in `BlogPostPage`:
 
 ```javascript
 // web/src/pages/BlogPostPage/BlogPostPage.js
 
-import BlogLayout from 'src/layouts/BlogLayout'
 import BlogPostCell from 'src/components/BlogPostCell'
 
 const BlogPostPage = () => {
   return (
-    <BlogLayout>
-      <BlogPostCell />
-    </BlogLayout>
+    <BlogPostCell />
   )
 }
 
@@ -108,14 +119,12 @@ export const Success = ({ post }) => {
 
 Okay, we're getting closer. Still, where will that `$id` come from? Redwood has another trick up its sleeve. Whenever you put a route param in a route, that param is automatically made available to the page that route renders. Which means we can update `BlogPostPage` to look like this:
 
-```javascript {3,6}
+```javascript {3,5}
 // web/src/pages/BlogPostPage/BlogPostPage.js
 
 const BlogPostPage = ({ id }) => {
   return (
-    <BlogLayout>
-      <BlogPostCell id={id} />
-    </BlogLayout>
+    <BlogPostCell id={id} />
   )
 }
 ```

--- a/docs/tutorial/saving-data.md
+++ b/docs/tutorial/saving-data.md
@@ -288,9 +288,9 @@ Next, let's show a notification to let the user know their submission was succes
 
 `useMutation` accepts an options object as a second argument. One of the options is a callback function, `onCompleted`, that will be invoked when the mutation successfully completes. We'll use that callback to invoke a `toast()` function which will add a message to be displayed in a **&lt;Toaster&gt;** component.
 
-Add the `onCompleted` callback to `useMutation` and include the **&lt;Toaster&gt;** component in our `return`, just inside the **&lt;BlogLayout&gt;**:
+Add the `onCompleted` callback to `useMutation` and include the **&lt;Toaster&gt;** component in our `return`, just before the **&lt;Form&gt;**. We also need to wrap it all in a fragment (&lt;&gt;&lt;/&gt;) because we are only allowed to return a single element:
 
-```javascript {5,10,11-15,21}
+```javascript {5,10-14,20}
 // web/src/pages/ContactPage/ContactPage.js
 
 // ...
@@ -311,6 +311,7 @@ const ContactPage = () => {
   return (
     <>
       <Toaster />
+      <Form onSubmit={onSubmit} validation={{ mode: 'onBlur' }}>
       // ...
     </>
   )
@@ -619,4 +620,3 @@ That's it! [React Hook Form](https://react-hook-form.com/) provides a bunch of [
 > ```
 
 The public site is looking pretty good. How about the administrative features that let us create and edit posts? We should move them to some kind of admin section and put them behind a login so that random users poking around at URLs can't create ads for discount pharmaceuticals.
-

--- a/docs/tutorial/saving-data.md
+++ b/docs/tutorial/saving-data.md
@@ -290,7 +290,7 @@ Next, let's show a notification to let the user know their submission was succes
 
 Add the `onCompleted` callback to `useMutation` and include the **&lt;Toaster&gt;** component in our `return`, just before the **&lt;Form&gt;**. We also need to wrap it all in a fragment (&lt;&gt;&lt;/&gt;) because we are only allowed to return a single element:
 
-```javascript {5,10-14,20}
+```javascript {5,10-14,19,20,23}
 // web/src/pages/ContactPage/ContactPage.js
 
 // ...

--- a/docs/tutorial/saving-data.md
+++ b/docs/tutorial/saving-data.md
@@ -178,7 +178,7 @@ We reference the `createContact` mutation we defined in the Contacts SDL passing
 
 Next we'll call the `useMutation` hook provided by Apollo which will allow us to execute the mutation when we're ready (don't forget the `import` statement):
 
-```javascript {11,15}
+```javascript {11,14}
 // web/src/pages/ContactPage/ContactPage.js
 
 import {
@@ -190,7 +190,6 @@ import {
   Label,
 } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 const ContactPage = () => {
   const [create] = useMutation(CREATE_CONTACT)
@@ -297,7 +296,6 @@ Add the `onCompleted` callback to `useMutation` and include the **&lt;Toaster&gt
 // ...
 import { useMutation } from '@redwoodjs/web'
 import { toast, Toaster } from '@redwoodjs/web/toast'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 // ...
 
@@ -311,9 +309,11 @@ const ContactPage = () => {
   // ...
 
   return (
-    <BlogLayout>
+    <>
       <Toaster />
       // ...
+    </>
+  )
 ```
 
 You can read the full documentation for Toast [here](https://redwoodjs.com/docs/toast-notifications).
@@ -432,7 +432,7 @@ import { toast, Toaster } from '@redwoodjs/web/toast'
 // ...
 
 return (
-  <BlogLayout>
+  <>
     <Toaster />
     <Form onSubmit={onSubmit} validation={{ mode: 'onBlur' }} error={error}>
       <FormError
@@ -489,7 +489,7 @@ Finally we'll tell `<Form>` to use the `formMethods` we just instantiated instea
 // web/src/pages/ContactPage/ContactPage.js
 
 return (
-  <BlogLayout>
+  <>
     <Toaster />
     <Form
       onSubmit={onSubmit}
@@ -532,7 +532,6 @@ import {
 import { useMutation } from '@redwoodjs/web'
 import { toast, Toaster } from '@redwoodjs/web/toast'
 import { useForm } from 'react-hook-form'
-import BlogLayout from 'src/layouts/BlogLayout'
 
 const CREATE_CONTACT = gql`
   mutation CreateContactMutation($input: CreateContactInput!) {
@@ -558,7 +557,7 @@ const ContactPage = () => {
   }
 
   return (
-    <BlogLayout>
+    <>
       <Toaster />
       <Form
         onSubmit={onSubmit}
@@ -604,7 +603,7 @@ const ContactPage = () => {
 
         <Submit disabled={loading}>Save</Submit>
       </Form>
-    </BlogLayout>
+    </>
   )
 }
 


### PR DESCRIPTION
Updates the tutorial so that it uses the new `<Set>` component to wrap layouts around pages in the Routes.js file, instead of each page importing the layout itself.