### PR TITLE
BlogPostsCell.js generated with the wrong Query

### DIFF
--- a/docs/tutorial/cells.md
+++ b/docs/tutorial/cells.md
@@ -64,7 +64,7 @@ This command will result in a new file at `/web/src/components/BlogPostsCell/Blo
 
 export const QUERY = gql`
   query BlogPostsQuery {
-    blogPosts {
+    posts {
       id
     }
   }
@@ -76,8 +76,8 @@ export const Empty = () => <div>Empty</div>
 
 export const Failure = ({ error }) => <div>Error: {error.message}</div>
 
-export const Success = ({ blogPosts }) => {
-  return JSON.stringify(blogPosts)
+export const Success = ({ bosts }) => {
+  return JSON.stringify(posts)
 }
 ```
 


### PR DESCRIPTION
 This happens in the **[Cell section](https://learn.redwoodjs.com/docs/tutorial/cells)**

![image](https://user-images.githubusercontent.com/2712405/112923463-59479380-90dc-11eb-8d43-cae9ab522c3f.png)