### PR TITLE
Fix missing line highlight in multiple-comments.md

### DIFF
--- a/docs/tutorial2/multiple-comments.md
+++ b/docs/tutorial2/multiple-comments.md
@@ -294,7 +294,7 @@ We're looping through each `comment` from the mock, the same mock used by Storyb
 
 The functionality we added to `<BlogPost>` says to show the comments for the post if we are *not* showing the summary. We've got a test for both the "full" and "summary" renders already. Generally you want your tests to be testing "one thing" so let's add two additional tests for our new functionality:
 
-```javascript {3,22-30,42-50}
+```javascript {3,5,22-30,42-50}
 // web/src/components/BlogPost/BlogPost.test.js
 
 import { render, screen, waitFor } from '@redwoodjs/testing'


### PR DESCRIPTION
Was following the 2nd tutorial, ran into some issues of 'standard' being not defined, turns out I missed copying it due to a missing highlight. Added it in order to help others.