### PR TITLE
[v0.33] Scaffold now wraps Routes in Set component

### DIFF
--- a/docs/tutorial/getting-dynamic.md
+++ b/docs/tutorial/getting-dynamic.md
@@ -128,7 +128,8 @@ Here's what happened when we ran that `yarn rw g scaffold post` command:
   - `NewPostPage` for creating a new post
   - `PostPage` for showing the detail of a post
   - `PostsPage` for listing all the posts
-- Created routes for those pages in `web/src/Routes.js`
+- Created a _layouts_ file in `web/src/layouts/PostsLayout.js` that serves as a container for pages with common elements like page heading and "New Posts" button
+- Created routes wrapped in the `Set` component with the layout as `PostsLayout` for those pages in `web/src/Routes.js`
 - Created three _cells_ in `web/src/components`:
   - `EditPostCell` gets the post to edit in the database
   - `PostCell` gets the post to display

--- a/docs/tutorial/getting-dynamic.md
+++ b/docs/tutorial/getting-dynamic.md
@@ -128,7 +128,7 @@ Here's what happened when we ran that `yarn rw g scaffold post` command:
   - `NewPostPage` for creating a new post
   - `PostPage` for showing the detail of a post
   - `PostsPage` for listing all the posts
-- Created a _layouts_ file in `web/src/layouts/PostsLayout.js` that serves as a container for pages with common elements like page heading and "New Posts" button
+- Created a _layouts_ file in `web/src/layouts/PostsLayout/PostsLayout.js` that serves as a container for pages with common elements like page heading and "New Posts" button
 - Created routes wrapped in the `Set` component with the layout as `PostsLayout` for those pages in `web/src/Routes.js`
 - Created three _cells_ in `web/src/components`:
   - `EditPostCell` gets the post to edit in the database


### PR DESCRIPTION
Docs updates for https://github.com/redwoodjs/redwood/pull/2609

To Do:
- [x] Add details about Routes now wrapping with Set in "Getting Dynamic" page.
- [x] Scaffold generates layout as well, update that too?

@jtoar Can you please check here? Is this the right way to do?
Feel free to scrape it if completely wrong, will re-create with correct instructions. :)