### PR TITLE
pin Node.js prerequisite to 14.x

### DIFF
--- a/docs/tutorial/prerequisites.md
+++ b/docs/tutorial/prerequisites.md
@@ -24,7 +24,7 @@ yarn redwood upgrade
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14"
+- node: "=14.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:


### PR DESCRIPTION
Only Node.js LTS is currently supported, which is v14. Both v15 and v16 will error.