### PR TITLE
tutorial: correct syntax for api test

### DIFF
--- a/docs/tutorial2/role-based-authorization-control-rbac.md
+++ b/docs/tutorial2/role-based-authorization-control-rbac.md
@@ -386,8 +386,10 @@ export const deleteComment = ({ id }) => {
 
 We'll need a test to go along with that functionality. How do we test `requireAuth()`? The api side also has a `mockCurrentUser()` function which behaves the same as the one on the web side:
 
-```javascript {5-15}
+```javascript {3,7-17}
 // api/src/services/comments/comments.test.js
+
+import { comments, createComment, deleteComment } from './comments'
 
 // ...
 
@@ -399,13 +401,13 @@ scenario('deletes a comment', async (scenario) => {
   })
   expect(comment.id).toEqual(scenario.comment.jane.id)
 
-  expect(
-    await db.comment.findUnique({ where: { id: scenario.comment.jane.id } })
-  ).toEqual(null)
+  const result = await comments({ postId: scenario.comment.jane.id })
+  expect(result.length).toEqual(0)
 })
+
 ```
 
-Our first expectation here checks that we get the deleted comment back from a call to `deleteComment()`. The second expectation make sure that the comment was actually removed from the database: trying to find a comment with that `id` now returns `null`.
+Our first expectation here checks that we get the deleted comment back from a call to `deleteComment()`. The second expectation make sure that the comment was actually removed from the database: trying to find a comment with that `id` now returns an empty array.
 
 ### Last Word on Roles
 


### PR DESCRIPTION
It seems that the web-side test syntax was used to improperly test the comment service on the api side.

Tests don't use `db` in this tutorial.

Also we needed to import `deleteComment`.