### PR TITLE
Updated suggested node version in Prequisites

### DIFF
--- a/docs/tutorial/prerequisites.md
+++ b/docs/tutorial/prerequisites.md
@@ -51,5 +51,5 @@ Please do upgrade accordingly. Then proceed to the Redwood installation when you
 >   - For **Linux** users, you can follow the [installation instructions from `nvm`](https://github.com/nvm-sh/nvm#installing-and-updating).
 > - We recommend **Windows** users visit [Nodejs.org](https://nodejs.org/en/) for installation.
 >
-> If you're confused about which of the two current Node versions to use, we recommend using the most recent "even" LTS, which is currently v14.
+> If you're confused about which of the two current Node versions to use, we recommend using the most recent LTS, which is currently [16.13.0](https://nodejs.org/download/release/v16.13.0/).
 


### PR DESCRIPTION
Solves the issue ([#3728](https://github.com/redwoodjs/redwood/issues/3728)) I had picking the right node version, 14.0.0 wasn't working for me. It would probably be better to either keep the version number updated, or just refer to node.js LTS, as 14.0.0 was an "even" version, but it's not working either. This could also lead to a page / table showing each an every node version that's compatible with redwood, instead of making newcomers guess.