### PR TITLE
Remove extra spaces from sample BlogPost body

### DIFF
--- a/docs/tutorial2/our-first-story.md
+++ b/docs/tutorial2/our-first-story.md
@@ -47,13 +47,7 @@ import BlogPost from './BlogPost'
 const POST = {
   id: 1,
   title: 'First Post',
-  body: `Neutra tacos hot chicken prism raw denim, put a bird on it
-         enamel pin post-ironic vape cred DIY. Street art next level
-         umami squid. Hammock hexagon glossier 8-bit banjo. Neutra
-         la croix mixtape echo park four loko semiotics kitsch forage
-         chambray. Semiotics salvia selfies jianbing hella shaman.
-         Letterpress helvetica vaporware cronut, shaman butcher YOLO
-         poke fixie hoodie gentrify woke heirloom.`,
+  body: `Neutra tacos hot chicken prism raw denim, put a bird on it enamel pin post-ironic vape cred DIY. Street art next level umami squid. Hammock hexagon glossier 8-bit banjo. Neutra la croix mixtape echo park four loko semiotics kitsch forage chambray. Semiotics salvia selfies jianbing hella shaman. Letterpress helvetica vaporware cronut, shaman butcher YOLO poke fixie hoodie gentrify woke heirloom.`,
 }
 
 export const full = () => {

--- a/docs/tutorial2/our-first-test.md
+++ b/docs/tutorial2/our-first-test.md
@@ -202,13 +202,7 @@ import BlogPost from './BlogPost'
 const POST = {
   id: 1,
   title: 'First post',
-  body: `Neutra tacos hot chicken prism raw denim, put a bird on it
-         enamel pin post-ironic vape cred DIY. Street art next level
-         umami squid. Hammock hexagon glossier 8-bit banjo. Neutra la
-         croix mixtape echo park four loko semiotics kitsch forage
-         chambray. Semiotics salvia selfies jianbing hella shaman.
-         Letterpress helvetica vaporware cronut, shaman butcher YOLO
-         poke fixie hoodie gentrify woke heirloom.`,
+  body: `Neutra tacos hot chicken prism raw denim, put a bird on it enamel pin post-ironic vape cred DIY. Street art next level umami squid. Hammock hexagon glossier 8-bit banjo. Neutra la croix mixtape echo park four loko semiotics kitsch forage chambray. Semiotics salvia selfies jianbing hella shaman. Letterpress helvetica vaporware cronut, shaman butcher YOLO poke fixie hoodie gentrify woke heirloom.`,
   createdAt: new Date().toISOString(),
 }
 
@@ -226,8 +220,7 @@ describe('BlogPost', () => {
     expect(screen.getByText(POST.title)).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Neutra tacos hot chicken prism raw denim, put a bird \
-        on it enamel pin post-ironic vape cred DIY. Str...'
+        'Neutra tacos hot chicken prism raw denim, put a bird on it enamel pin post-ironic vape cred DIY. Str...'
       )
     ).toBeInTheDocument()
   })


### PR DESCRIPTION
Fixes this issue: [Tutorial II provides sample blog post body with extra spacing, BlogPost test fails by default](https://github.com/redwoodjs/learn.redwoodjs.com/issues/180)

This PR fixes a really minor bug, so it's not a high priority.