### PR TITLE
Correct BlogPost story and test line numbers

### DIFF
--- a/docs/tutorial2/our-first-story.md
+++ b/docs/tutorial2/our-first-story.md
@@ -39,7 +39,7 @@ We'll pass an additional `summary` prop to the component to let it know if it sh
 
 Now in the Storybook story let's create a `summary` story that uses **BlogPost** the same way that `generated` does, but adds the new prop. We'll take the content of the sample post and put that in a constant that both stories will use. We'll also rename `generated` to `full` to make it clear what's different between the two:
 
-```javascript {5-14,16-18,20-22}
+```javascript {5-9,11-13,15-17}
 // web/components/BlogPost/BlogPost.stories.js
 
 import BlogPost from './BlogPost'

--- a/docs/tutorial2/our-first-test.md
+++ b/docs/tutorial2/our-first-test.md
@@ -20,7 +20,7 @@ The test was looking for the full text of the blog post, but remember that in **
 
 Let's update the test so that it checks for the expected behavior instead. There are entire books written on the best way to test, so no matter what we decide on testing in this code there will be someone out there to tell us we're doing it wrong. As just one example, the simplest test would be to just copy what's output and use that for the text in the test:
 
-```javascript {7-8}
+```javascript {7-12}
 // web/src/components/BlogPostsCell.test.js
 
 test('Success renders successfully', async () => {
@@ -28,7 +28,11 @@ test('Success renders successfully', async () => {
   render(<Success posts={posts} />)
 
   expect(screen.getByText(posts[0].title)).toBeInTheDocument()
-  expect(screen.getByText("Neutra tacos hot chicken prism raw denim, put a bird on it enamel pin post-ironic vape cred DIY. Str...")).toBeInTheDocument()
+  expect(
+    screen.getByText(
+      'Neutra tacos hot chicken prism raw denim, put a bird on it enamel pin post-ironic vape cred DIY. Str...'
+    )
+  ).toBeInTheDocument()
 })
 ```
 
@@ -193,7 +197,7 @@ In this case let's just test that the output matches an exact string. You could 
 
 We'll move the sample post data to a constant and then use it in both the existing test (which tests that not passing the `summary` prop at all results in the full body being rendered) and our new test that checks for the summary version being rendered:
 
-```javascript {6-17,21,23-24,27-37}
+```javascript {6-11,15,17-18,21-30}
 // web/src/components/BlogPost/BlogPost.test.js
 
 import { render, screen } from '@redwoodjs/testing'


### PR DESCRIPTION
Corrects line highlighting oversight in [this PR](https://github.com/redwoodjs/learn.redwoodjs.com/pull/181), addresses [this issue](https://github.com/redwoodjs/learn.redwoodjs.com/issues/180).

I also slightly refactored a related code block, and this time I did remember to adjust code highlighting accordingly!