### PR TITLE
Comment mutations missing auth decorators in sample sdl code

### DIFF
--- a/docs/tutorial2/adding-comments-to-the-schema.md
+++ b/docs/tutorial2/adding-comments-to-the-schema.md
@@ -249,6 +249,8 @@ export const deleteComment = ({ id }) => {
 }
 ```
 
+Since we only want owners of the blog to be able to delete comments, we'll use `@requireAuth`.
+
 ```graphql {5}
 // api/src/graphql/comments.sdl.js
 

--- a/docs/tutorial2/adding-comments-to-the-schema.md
+++ b/docs/tutorial2/adding-comments-to-the-schema.md
@@ -253,8 +253,8 @@ export const deleteComment = ({ id }) => {
 // api/src/graphql/comments.sdl.js
 
 type Mutation {
-  createComment(input: CreateCommentInput!): Comment!
-  deleteComment(id: Int!): Comment!
+  createComment(input: CreateCommentInput!): Comment! @skipAuth
+  deleteComment(id: Int!): Comment! @requireAuth
 }
 ```
 

--- a/docs/tutorial2/adding-comments-to-the-schema.md
+++ b/docs/tutorial2/adding-comments-to-the-schema.md
@@ -249,7 +249,7 @@ export const deleteComment = ({ id }) => {
 }
 ```
 
-Since we only want owners of the blog to be able to delete comments, we'll use `@requireAuth`.
+Since we only want owners of the blog to be able to delete comments, we'll use `@requireAuth`:
 
 ```graphql {5}
 // api/src/graphql/comments.sdl.js


### PR DESCRIPTION
This PR adds missing auth decorators from `Comment` mutations in [sample sdl code](https://learn.redwoodjs.com/docs/tutorial2/adding-comments-to-the-schema#building-out-the-service) in Tutorial II.  It also adds a small explanation for why `deleteComment` should require authorization.