### PR TITLE
Remove prisma seed command

### DIFF
--- a/docs/tutorial2/prerequisites.md
+++ b/docs/tutorial2/prerequisites.md
@@ -44,7 +44,6 @@ git clone https://github.com/redwoodjs/redwood-tutorial
 cd redwood-tutorial
 yarn install
 yarn rw prisma migrate dev
-yarn rw prisma db seed
 yarn rw dev
 ```
 


### PR DESCRIPTION
Now that https://github.com/redwoodjs/redwood-tutorial/pull/18 has been merged, the tutorial documentation should be updated.

According to https://www.prisma.io/docs/guides/database/seed-database#integrated-seeding-with-prisma-migrate, seeding now happens automatically in `prisma migrate dev`.  I know seeding automatically occurred after running `yarn rw prisma migrate dev` while I was using SQLite, but after switching to postgresql I had to run `yarn rw prisma db seed` again.  I don't think we should list it as a "get up and running" command in the README file, because with the initial SQLite configuration this command will end up double-seeding the database (so the user will start with 6 posts, 2 copies of each seed post).