### PR TITLE
Update routing-params tutorial doc

### DIFF
--- a/docs/tutorial/routing-params.md
+++ b/docs/tutorial/routing-params.md
@@ -65,7 +65,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 <Link to={routes.blogPost({ id: post.id })}>{post.title}</Link>
 ```
 
-For routes with route parameters, the named route function expects an object where you specify a value for each parameter. If you click on the link now, it will indeed take you to `/blog-post/1` (or `/blog-post/2`, etc, depending on the ID of the post).
+For routes with route parameters, the named route function expects an object where you specify a value for each parameter. If you click on the link now, it will take you to `/blog-post/1` (or `/blog-post/2`, etc, depending on the ID of the post). As the BlogPostPage boilerplate references the blog post route without a parameter in a link, we have to remove the link for the page to display.
 
 ### Using the Param
 


### PR DESCRIPTION
In the tutorial, once requiring the blog post route to have a parameter, the page will not display as the following link in the boilerplate is now invalid:
```
 My default route is named <code>blogPost</code>, link to me with `
        <Link to={routes.blogPost()}>BlogPost</Link>
```
It is natural for users to test a link and click it after creating it and if they do so they are greeted with the error page with the console error ```Uncaught Error: Missing parameter 'id' for route '/blog-post/{id}'.``` . 

The error may be construed by users who are not familiar with the boilerplate code as telling them they did not set up their route params correctly.
This might be a roadblock for those following the tutorial and so the aim of this text added is to clarify what is occurring if tutorial followers run into this error. Another way could be to get followers to change the boilerplate code earlier but as we are deleting all the boilerplate in the next step I don't think this is necessary. As always open to other ways to approach