### PR TITLE
`BlogPost` wasn't inline with the rw-tutorial repo

### DIFF
--- a/docs/tutorial2/introduction-to-storybook.md
+++ b/docs/tutorial2/introduction-to-storybook.md
@@ -16,9 +16,9 @@ After some compiling you should get a message saying that Storybook has started 
 
 If you poke around at the file tree on the left you'll see all of the components, cells, layouts and pages we created during the tutorial. Where did they come from? You may recall that every time we generated a new page/cell/component we actually created at least *three* files:
 
-* BlogPost.js
-* BlogPost.stories.js
-* BlogPost.test.js
+* Article.js
+* Article.stories.js
+* Article.test.js
 
 > If you generated a cell then you also got a `.mock.js` file (more on those later).
 
@@ -28,17 +28,17 @@ Those `.stories.js` files are what makes the tree on the left side of the Storyb
 
 So, the idea here is that you can build out your components/cells/pages in isolation, get them looking the way you want and displaying the correct data, then plug them into your full application.
 
-When Storybook opened it should have opened **Components > BlogPost > Generated** which is the generated component we created to display a single blog post. If you open `web/src/components/BlogPost/BlogPost.stories.js` you'll see what it takes to explain this component to Storybook, and it isn't much:
+When Storybook opened it should have opened **Components > Article > Generated** which is the generated component we created to display a single article. If you open `web/src/components/Article/Article.stories.js` you'll see what it takes to explain this component to Storybook, and it isn't much:
 
 ```javascript
-// web/src/components/BlogPost/BlogPost.stories.js
+// web/src/components/Article/Article.stories.js
 
-import BlogPost from './BlogPost'
+import Article from './Article'
 
 export const generated = () => {
   return (
-    <BlogPost
-      post={{
+    <Article
+      article={{
         id: 1,
         title: 'First Post',
         body: `Neutra tacos hot chicken prism raw denim, put a bird on it
@@ -54,18 +54,18 @@ export const generated = () => {
   )
 }
 
-export default { title: 'Components/BlogPost' }
+export default { title: 'Components/Article' }
 ```
 
 You import the component you want to use and then all of the named exports in the file will be a single "story" as displayed in Storybook. In this case the generator named it "generated" which shows as the "Generated" story in the tree view:
 
 ```bash
 Components
-└── BlogPost
+└── Article
     └── Generated
 ```
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-> Where did that sample blog post data come from? We (the Redwood team) added that to the story in the `redwood-tutorial` repo to show you what a story might look like after you hook up some sample data. Several of the stories need data like this, some inline and some in those `mock.js` files. The rest of the tutorial will be showing you how to do this yourself with new components as you create them.
+> Where did that sample aticle data come from? We (the Redwood team) added that to the story in the `redwood-tutorial` repo to show you what a story might look like after you hook up some sample data. Several of the stories need data like this, some inline and some in those `mock.js` files. The rest of the tutorial will be showing you how to do this yourself with new components as you create them.
 


### PR DESCRIPTION
Replaced `BlogPost` and `blog post` with `Article` and `article`. The image still shows BlogPost instead of Article in the file tree