### PR TITLE
Fix diff highlight of ArticlesCell

### DIFF
--- a/docs/tutorial/cells.md
+++ b/docs/tutorial/cells.md
@@ -162,7 +162,7 @@ export const Success = ({ posts }) => {
 
 Let's plug this cell into our `HomePage` and see what happens:
 
-```javascript {3,7}
+```javascript {5, 11}
 // web/src/pages/HomePage/HomePage.js
 
 import { MetaTags } from '@redwoodjs/web'


### PR DESCRIPTION
The diff highlight it not right for the example:
![Screenshot from 2022-03-06 18-23-51](https://user-images.githubusercontent.com/18013532/156946777-20ecae46-356a-4972-ba3e-4f8c4892c15f.PNG)
