### PR TITLE
Add issue and pr templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,16 @@
+---
+name: Issue template
+about: Docs Migration
+title: ''
+labels: ''
+assignees: ''
+
+---
+🚨 HEADS UP
+
+In preparation for the 1.0.0 release, the Redwood Docs have been integrated with the main Redwood Framework redwoodjs/redwood repo. We are in the final stages of the migration. Once complete, this repo will be archived.
+
+> Please do not open new Issues here. Instead, open them at https://github.com/redwoodjs/redwood/issues
+
+The new doc site uses Docusaurus. The Docs are located here:
+- https://github.com/redwoodjs/redwood/tree/main/docs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+🚨 HEADS UP
+
+In preparation for the 1.0.0 release, the Redwood Docs have been integrated with the main Redwood Framework redwoodjs/redwood repo. We are in the final stages of the migration. Once complete, this repo will be archived.
+
+> Please do not open new PRs here. Instead, open them at https://github.com/redwoodjs/redwood/pulls
+
+The new doc site uses Docusaurus. The Docs are located here:
+- https://github.com/redwoodjs/redwood/tree/main/docs


### PR DESCRIPTION
We've moved the docs to the [redwoodjs/redwood](https://github.com/redwoodjs/redwood/tree/main/docs/docs) repo!